### PR TITLE
Feature/revision changes

### DIFF
--- a/src/Components/Footer/Footer.jsx
+++ b/src/Components/Footer/Footer.jsx
@@ -164,6 +164,9 @@ const Footer = () => {
             <Link to="/getinvolved" className="hover:text-gray-500">
               Get Involved
             </Link>
+            <Link to="/getinvolved#careers" className="hover:text-gray-500">
+             Careers
+            </Link>
             <Link to="/oursolutions" className="hover:text-gray-500">
               Our Solutions
             </Link>

--- a/src/Components/Navbar/Navbar.jsx
+++ b/src/Components/Navbar/Navbar.jsx
@@ -125,14 +125,14 @@ const Navbar = () => {
                   Success Stories
                 </Link>
               </li>
-              <li>
+              {/* <li>
                 <Link
                   to="getinvolved#faq"
                   className="text-white hover:text-gray-500 transition duration-[200ms] ease-linear"
                 >
                   FAQ
                 </Link>
-              </li>
+              </li> */}
               <li>
                 <Link
                   to="contactus"

--- a/src/Components/Navbar/Navbar.jsx
+++ b/src/Components/Navbar/Navbar.jsx
@@ -95,6 +95,14 @@ const Navbar = () => {
               </li>
               <li>
                 <Link
+                  to="getinvolved#careers"
+                  className="text-white hover:text-gray-500 transition duration-[200ms] ease-linear"
+              >
+                Careers
+              </Link>
+              </li>
+              <li>
+                <Link
                   to="oursolutions"
                   className="text-white hover:text-gray-500 transition duration-[200ms] ease-linear"
                 >

--- a/src/Components/Navbar/Navbar.jsx
+++ b/src/Components/Navbar/Navbar.jsx
@@ -49,13 +49,13 @@ const Navbar = () => {
           >
             Donate
           </button>
-          <button
+          {/* <button
             disabled
             // className="hidden md:block w-[80px] h-[36px] border-primary500 border-solid border-[4px] rounded-full hover:bg-primary300 transition duration-[300ms] ease-linear text-[1rem] text-primary500 hover:text-fontSecondary font-semibold"
             className="hidden md:block w-[80px] h-[36px] border-greyCustom border-solid border-[4px] rounded-full transition duration-[300ms] ease-linear text-[1rem] text-greyCustom hover:text-greyCustom font-semibold"
           >
             Login
-          </button>
+          </button> */}
 
           <div className="text-[2rem] cursor-pointer text-white flex items-center justify-center">
             {isOpen ? (
@@ -133,14 +133,14 @@ const Navbar = () => {
                   Contact Us
                 </Link>
               </li>
-              <li className="md:hidden">
+              {/* <li className="md:hidden">
                 <button
                   // className="w-[116px] h-[47px] border-primary500 border-solid border-[4px] rounded-full hover:bg-primary300 transition duration-[300ms] ease-linear text-primary500 hover:text-fontSecondary font-semibold"
                   className="w-[116px] h-[47px] border-greyCustom border-solid border-[4px] rounded-full transition duration-[300ms] ease-linear text-greyCustom hover:text-greyCustom font-semibold"
                 >
                   Login
                 </button>
-              </li>
+              </li> */}
             </ul>
           </div>
         ) : null}

--- a/src/Pages/Careers/Careers.jsx
+++ b/src/Pages/Careers/Careers.jsx
@@ -1,43 +1,64 @@
-import React, { useEffect, useState } from "react";
+import React, { useEffect, useState, useRef } from "react";
 import LoadingSpinner from "../../Components/KeelBot/LoadingSpinner/LoadingSpinner";
 
+const charLimit = 220; // change if you want a different truncate length
+
+/* ────────────────────────────────────────────────────────── */
 const Careers = () => {
   const [jobs, setJobs] = useState([]);
   const [loading, setLoading] = useState(true);
   const [currentPage, setCurrentPage] = useState(1);
+  const [expandedIds, setExpandedIds] = useState(new Set());
   const jobsPerPage = 6;
 
+  /* scroll‑to‑top ref */
+  const topRef = useRef(null);
+
+  /* fetch jobs */
   useEffect(() => {
-    fetch("https://script.google.com/macros/s/AKfycbzL3qgWF2-yrCgQcgQXEbscWm-KugU1Q32wFgEDGKJYk1ePc4dVmgN_DAFiBsPktWcO/exec")
-      .then((res) => res.json())
-      .then((data) => {
-        const openJobs = data.filter((job) => job.Status === "Open");
+    fetch(
+      "https://script.google.com/macros/s/AKfycbzL3qgWF2-yrCgQcgQXEbscWm-KugU1Q32wFgEDGKJYk1ePc4dVmgN_DAFiBsPktWcO/exec"
+    )
+      .then(res => res.json())
+      .then(data => {
+        const openJobs = data.filter(job => job.Status === "Open");
         setJobs(openJobs);
         setLoading(false);
       })
-      .catch((error) => {
-        console.error("Error fetching job listings:", error);
+      .catch(err => {
+        console.error("Error fetching job listings:", err);
         setLoading(false);
       });
   }, []);
 
-  const handleApply = (job) => {
-    if (job.FormURL) {
-      window.open(job.FormURL, "_blank");
-    } else {
-      alert("Application form not available for this position.");
+  /* open application form */
+  const handleApply = job =>
+    job.FormURL
+      ? window.open(job.FormURL, "_blank")
+      : alert("Application form not available for this position.");
+
+  /* pagination calc */
+  const indexOfLastJob = currentPage * jobsPerPage;
+  const currentJobs = jobs.slice(indexOfLastJob - jobsPerPage, indexOfLastJob);
+  const totalPages = Math.ceil(jobs.length / jobsPerPage);
+
+  /* page change + scroll to top */
+  const handlePageChange = page => {
+    if (page >= 1 && page <= totalPages) {
+      setCurrentPage(page);
+      if (topRef.current) {
+        topRef.current.scrollIntoView({ behavior: "smooth", block: "start" });
+      }
     }
   };
 
-  const indexOfLastJob = currentPage * jobsPerPage;
-  const indexOfFirstJob = indexOfLastJob - jobsPerPage;
-  const currentJobs = jobs.slice(indexOfFirstJob, indexOfLastJob);
-  const totalPages = Math.ceil(jobs.length / jobsPerPage);
-
-  const handlePageChange = (page) => {
-    if (page >= 1 && page <= totalPages) {
-      setCurrentPage(page);
-    }
+  /* toggle read‑more */
+  const toggleExpand = idx => {
+    setExpandedIds(prev => {
+      const next = new Set(prev);
+      next.has(idx) ? next.delete(idx) : next.add(idx);
+      return next;
+    });
   };
 
   if (loading) {
@@ -50,7 +71,11 @@ const Careers = () => {
 
   return (
     <div className="px-4 md:px-8 py-12">
-      <h2 className="text-3xl md:text-4xl font-bold mb-10 text-center">
+      {/* topRef ensures we can scroll back here */}
+      <h2
+        ref={topRef}
+        className="text-3xl md:text-4xl font-bold mb-10 text-center"
+      >
         Career Opportunities
       </h2>
 
@@ -60,40 +85,69 @@ const Careers = () => {
             No openings available at this time. Please check back later.
           </p>
         ) : (
-          currentJobs.map((job, index) => (
-            <div
-              key={index}
-              className="job-card bg-white p-6 rounded-lg shadow-lg transition-all hover:shadow-2xl hover:scale-[1.03] flex flex-col h-full animate-fadeInUp"
-              style={{ animationDelay: `${index * 80}ms` }}
-            >
-              <div className="flex flex-col h-full">
-                <div className="mb-6">
-                  <h3 className="text-xl font-bold mb-3">{job.Title}</h3>
-                  <div className="mb-4">
-                    <p className="text-gray-700">
-                      <strong>Location:</strong> {job.Location}
-                    </p>
-                    <p className="text-gray-700">
-                      <strong>Type:</strong> <span className="inline-block px-2 py-0.5 rounded bg-primary100 text-primary500 text-xs font-semibold ml-1">{job.Type}</span>
+          currentJobs.map((job, idx) => {
+            const globalIdx = (currentPage - 1) * jobsPerPage + idx;
+            const isExpanded = expandedIds.has(globalIdx);
+            const shortText =
+              job.Description.length > charLimit
+                ? job.Description.slice(0, charLimit) + "…"
+                : job.Description;
+
+            return (
+              <div
+                key={globalIdx}
+                className="job-card bg-white p-6 rounded-lg shadow-lg transition-all hover:shadow-2xl hover:scale-[1.03] flex flex-col h-full animate-fadeInUp"
+                style={{ animationDelay: `${idx * 80}ms` }}
+              >
+                <div className="flex flex-col h-full">
+                  {/* header & meta */}
+                  <div className="mb-6">
+                    <h3 className="text-xl font-bold mb-3">{job.Title}</h3>
+                    <div className="mb-4">
+                      <p className="text-gray-700">
+                        <strong>Location:</strong> {job.Location}
+                      </p>
+                      <p className="text-gray-700">
+                        <strong>Type:</strong>
+                        <span className="inline-block px-2 py-0.5 rounded bg-primary100 text-primary500 text-xs font-semibold ml-1">
+                          {job.Type}
+                        </span>
+                      </p>
+                    </div>
+
+                    {/* description + read more */}
+                    <p className="text-gray-600">
+                      {isExpanded ? job.Description : shortText}
+                      {job.Description.length > charLimit && (
+                        <button
+                          className="ml-2 text-primary500 font-semibold hover:underline focus:outline-none"
+                          onClick={() => toggleExpand(globalIdx)}
+                        >
+                          {isExpanded ? "Read Less" : "Read More"}
+                        </button>
+                      )}
                     </p>
                   </div>
-                  <p className="text-gray-600">{job.Description}</p>
-                </div>
 
-                <button
-                  className="mt-auto w-full bg-primary500 text-white px-4 py-2 rounded-full hover:bg-primary300 transition duration-300 font-semibold relative overflow-hidden ripple"
-                  onClick={e => { handleApply(job); createRipple(e); }}
-                  type="button"
-                >
-                  Apply Now
-                </button>
+                  {/* apply button */}
+                  <button
+                    type="button"
+                    className="mt-auto w-full bg-primary500 text-white px-4 py-2 rounded-full hover:bg-primary300 transition duration-300 font-semibold relative overflow-hidden ripple"
+                    onClick={e => {
+                      handleApply(job);
+                      createRipple(e);
+                    }}
+                  >
+                    Apply Now
+                  </button>
+                </div>
               </div>
-            </div>
-          ))
+            );
+          })
         )}
       </div>
 
-      {/* Pagination */}
+      {/* pagination */}
       {totalPages > 1 && (
         <div className="flex justify-center mt-10 space-x-2">
           <button
@@ -131,20 +185,22 @@ const Careers = () => {
   );
 };
 
-// Ripple effect for Apply button
+/* ripple effect helper */
 function createRipple(event) {
   const button = event.currentTarget;
   const circle = document.createElement("span");
   const diameter = Math.max(button.clientWidth, button.clientHeight);
   const radius = diameter / 2;
   circle.style.width = circle.style.height = `${diameter}px`;
-  circle.style.left = `${event.clientX - button.getBoundingClientRect().left - radius}px`;
-  circle.style.top = `${event.clientY - button.getBoundingClientRect().top - radius}px`;
+  circle.style.left = `${
+    event.clientX - button.getBoundingClientRect().left - radius
+  }px`;
+  circle.style.top = `${
+    event.clientY - button.getBoundingClientRect().top - radius
+  }px`;
   circle.classList.add("ripple-effect");
-  const ripple = button.getElementsByClassName("ripple-effect")[0];
-  if (ripple) {
-    ripple.remove();
-  }
+  const oldRipple = button.getElementsByClassName("ripple-effect")[0];
+  if (oldRipple) oldRipple.remove();
   button.appendChild(circle);
   setTimeout(() => circle.remove(), 600);
 }

--- a/src/Pages/GetInvolved/GetInvolved.jsx
+++ b/src/Pages/GetInvolved/GetInvolved.jsx
@@ -17,7 +17,7 @@ const GetInvolved = () => {
       <BecomeVolunteer />
 
       
-      <section className="bg-grey200 px-6 md:px-16 lg:px-24 py-10">
+      <section id="careers" className="bg-grey200 px-6 md:px-16 lg:px-24 py-10">
         <div className="max-w-6xl mx-auto">
           <Careers />
         </div>

--- a/src/Pages/GetInvolved/Hero/Hero.jsx
+++ b/src/Pages/GetInvolved/Hero/Hero.jsx
@@ -1,72 +1,82 @@
+import { Link } from "react-router-dom";
 import greaterImg from "../../../assets/images/greater.png";
 
-const Hero = () => {
-  return (
-    <div className="w-screen lg:min-h-[800px] mt-[5rem] bg-white flex justify-center items-center font-Inter">
-      <div className="w-full max-w-[3000px] h-full overflow-hidden relative bg-white flex justify-center items-start">
-        <div className="flex items-start md:items-center justify-center flex-col xl:h-full w-full h-full mx-[1rem] md:mx-[2rem] lg:mx-[8rem]">
-          <div>
-            <p className="text-[2rem] leading-[3.5rem] md:text-[3rem] md:leading-[3.5rem] lg:text-[3.5rem] lg:leading-[4rem] font-bold text-[#2E2E2E] mb-[2rem] mt-[4rem] lg:mt-[0]">
-              Get Involved
-            </p>
+const Hero = () => (
+  <div className="w-screen lg:min-h-[800px] mt-[5rem] bg-white flex justify-center items-center font-Inter">
+    <div className="w-full max-w-[3000px] h-full overflow-hidden relative bg-white flex justify-center items-start">
+      <div className="flex items-start md:items-center justify-center flex-col xl:h-full w-full h-full mx-[1rem] md:mx-[2rem] lg:mx-[8rem]">
+
+        {/* ────────────── Heading & Intro ────────────── */}
+        <p className="text-[2rem] md:text-[3rem] lg:text-[3.5rem] font-bold text-[#2E2E2E] mb-[2rem] mt-[4rem] lg:mt-0 leading-[3.5rem] lg:leading-[4rem]">
+          Get Involved
+        </p>
+
+        <p className="text-[#646464] font-bold text-[2rem] md:text-[2.5rem] md:mt-10 md:text-center leading-[3.5rem]">
+          Together, WE can do <span className="text-primary500">ANYTHING</span>
+        </p>
+
+        <div className="text-[1rem] md:text-[1.75rem] text-[#646464] md:text-center leading-[1.6] my-8 md:my-[3.5rem] lg:my-8">
+          <p>
+            KeelWorks is committed to helping individuals achieve sustainable
+            employment. The KeelMaster program is our most ambitious program
+            yet, designed to engage participants without any skills or technical
+            knowledge.
+          </p>
+          <br />
+          <p>Our program is taking shape—join us in making a difference!</p>
+        </div>
+
+        {/* ────────────── 3‑Column CTA List ────────────── */}
+        <div className="xl:mt-[40px] grid grid-cols-1 md:grid-cols-3 gap-4 md:gap-24 mb-[4rem] lg:mb-0">
+
+          {/* 01 ─ Donation */}
+          <div className="relative md:ml-6">
+            <h1 className="text-[2rem] md:text-[2.5rem] font-bold text-[#646464]">01</h1>
+            <p className="text-[1rem] text-[#646464]">Making a donation</p>
+
+            <button
+              onClick={() =>
+                window.open(
+                  "https://www.every.org/keelworks-foundation?utm_campaign=donate-link&method=card%2Cbank%2Cpaypal%2Cpay%2Cvenmo%2Cgift%2Cstocks%2Cdaf#/donate",
+                  "_blank"
+                )
+              }
+              className="flex items-center mt-1 text-primary500 font-bold text-[0.875rem] hover:underline"
+            >
+              More Details
+              <img src={greaterImg} alt="" className="mx-2 w-2 h-2" />
+            </button>
+
+            <div className="absolute top-0 right-0 h-full w-px bg-[#646464]" />
           </div>
-          <div className="text-[#646464] font-bold text-[2rem] leading-[3.5rem] md:text-[2.5rem] md:mt-10 md:text-center">
-            <p>
-              Together, WE can do{" "}
-              <span className="text-primary500 ">ANYTHING</span>{" "}
-            </p>
+
+          {/* 02 ─ Volunteer / Careers */}
+          <div className="relative">
+            <h1 className="text-[2rem] md:text-[2.5rem] font-bold text-[#646464]">02</h1>
+            <p className="text-[1rem] text-[#646464]">Volunteer</p>
+            <p className="text-[1rem] text-[#646464]">(see below)</p>
+
+            <Link
+              to="/getinvolved#careers"
+              className="flex items-center mt-1 text-primary500 font-bold text-[0.875rem] hover:underline"
+            >
+              More Details
+              <img src={greaterImg} alt="" className="mx-2 w-2 h-2" />
+            </Link>
+
+            <div className="absolute top-0 right-0 h-full w-px bg-[#646464]" />
           </div>
-          <div className="text-[1rem] md:text-[1.75rem] text-[#646464] md:text-center leading-[1.6] my-8 md:my-[3.5rem] lg:my-8">
-            <p className="whitespace-normal">
-              KeelWorks is committed to helping individuals achieve sustainable employment. The KeelMaster program is our most ambitious program yet, designed to engage participants without any skills or technical knowledge.
-            </p>
-            <br/>
-            <p>
-              Our program is taking shape—join us in making a difference!
-            </p>
-          </div>
-          <div className="xl:mt-[40px] grid grid-cols-1 md:grid-cols-3 gap-4 justify-start md:gap-24 mb-[4rem] lg:mb-[0]">
-            <div className="relative md:ml-6">
-              <h1 className="text-[2rem] md:text-[2.5rem] font-bold text-[#646464]">
-                01
-              </h1>
-              <p className="text-[1rem] text-[#646464]">Making a donation</p>
-              <div className="flex justify-start items-center">
-                <span className="text-primary500 font-bold text-[0.875rem]">
-                  More Details
-                </span>
-                <img src={greaterImg} alt="" className="mx-2 w-2 xl:h-2" />
-              </div>
-              <div className="absolute top-0 right-0 h-full w-px bg-[#646464]"></div>
-            </div>
-            <div className="relative">
-              <h1 className="text-[2rem] md:text-[2.5rem] font-bold text-[#646464]">
-                02
-              </h1>
-              <p className="text-[1rem] text-[#646464]">Volunteer</p>
-              <p className="text-[1rem] text-[#646464]">(see below)</p>
-              <div className="flex justify-start items-center">
-                <span className="text-primary500 font-bold text-[0.875rem]">
-                  More Details
-                </span>
-                <img src={greaterImg} alt="" className="mx-2 w-2 h-2" />
-              </div>
-              <div className="absolute top-0 right-0 h-full w-px bg-[#646464]"></div>
-            </div>
-            <div className="relative">
-              <h1 className="text-[2rem] md:text-[2.5rem] font-bold text-[#646464]">
-                03
-              </h1>
-              <p className="text-[1rem] text-[#646464]">
-                Encourage others to donate{" "}
-              </p>
-              <p className="text-[1rem] text-[#646464]">or volunteer</p>
-            </div>
+
+          {/* 03 ─ Encourage others */}
+          <div className="relative">
+            <h1 className="text-[2rem] md:text-[2.5rem] font-bold text-[#646464]">03</h1>
+            <p className="text-[1rem] text-[#646464]">Encourage others to donate</p>
+            <p className="text-[1rem] text-[#646464]">or volunteer</p>
           </div>
         </div>
       </div>
     </div>
-  );
-};
+  </div>
+);
 
 export default Hero;

--- a/src/Pages/GetInvolved/Hero/Hero.jsx
+++ b/src/Pages/GetInvolved/Hero/Hero.jsx
@@ -53,8 +53,8 @@ const Hero = () => (
           {/* 02 ─ Volunteer / Careers */}
           <div className="relative">
             <h1 className="text-[2rem] md:text-[2.5rem] font-bold text-[#646464]">02</h1>
-            <p className="text-[1rem] text-[#646464]">Volunteer</p>
-            <p className="text-[1rem] text-[#646464]">(see below)</p>
+            <p className="text-[1rem] text-[#646464]">Become a volunteer</p>
+            {/* <p className="text-[1rem] text-[#646464]">(see below)</p> */}
 
             <Link
               to="/getinvolved#careers"

--- a/src/Pages/GetInvolved/VolunteersSay/VolunteersSay.jsx
+++ b/src/Pages/GetInvolved/VolunteersSay/VolunteersSay.jsx
@@ -1,3 +1,6 @@
+import React, { useState } from "react";
+import ImageFrame from "../../../Components/ImageFrame/ImageFrame";
+
 import Volunteer1 from "../../../assets/images/Get-Involved/Volunteer1.jpg";
 import Volunteer2 from "../../../assets/images/Get-Involved/Volunteer2.png";
 import Volunteer3 from "../../../assets/images/Get-Involved/Eric.png";
@@ -5,7 +8,8 @@ import Volunteer4 from "../../../assets/images/Get-Involved/Madelyn.png";
 import Volunteer5 from "../../../assets/images/Get-Involved/Likith.png";
 import Volunteer6 from "../../../assets/images/Get-Involved/Thota-S.png";
 import Volunteer7 from "../../../assets/images/Get-Involved/Fredi-S.png";
-import ImageFrame from "../../../Components/ImageFrame/ImageFrame";
+
+const charLimit = 300;
 
 const volunteers = [
   {
@@ -85,46 +89,63 @@ const volunteers = [
 ];
 
 const VolunteersSay = () => {
+  const [expandedIds, setExpandedIds] = useState(new Set());
+
+  const toggleExpand = id =>
+    setExpandedIds(prev => {
+      const next = new Set(prev);
+      next.has(id) ? next.delete(id) : next.add(id);
+      return next;
+    });
+
   return (
     <div className="w-screen flex justify-start md:justify-center md:items-center flex-col">
-      <div className="max-w-[3000px] flex flex-col md:items-center overflow-hidden my-[2rem] md:mt-[4rem] md:mb-[4rem] text-[2rem] md:text-6xl font-bold mx-[1rem] md:mx-[2rem] lg:mx-[8rem]">
+      <h2 className="max-w-[3000px] my-[2rem] md:my-[4rem] mx-[1rem] md:mx-[2rem] lg:mx-[8rem] text-[2rem] md:text-6xl font-bold">
         What Our Volunteers Say
-      </div>
-      <div className="max-w-[1050px] h-full flex flex-col items-center justify-center gap-[2rem] mx-[1rem] md:mx-[2rem] lg:mx-[8rem]">
-        {volunteers.map((volunteer, index) => {
+      </h2>
+
+      <div className="max-w-[1050px] flex flex-col items-center gap-[2rem] mx-[1rem] md:mx-[2rem] lg:mx-[8rem]">
+        {volunteers.map((v, idx) => {
+          const isExpanded = expandedIds.has(v.id);
+          const fullText = [v.content1, v.content2, v.content3].filter(Boolean).join(" ");
+          const shortText =
+            fullText.length > charLimit ? fullText.slice(0, charLimit) + "…" : fullText;
+
           return (
             <div
-              key={index}
-              className={`w-full flex flex-col justify-center lg:justify-between items-end mb-[4rem] ${
-                index % 2 === 0
-                  ? "md:flex md:flex-row md:items-start"
-                  : "md:flex md:flex-row-reverse md:items-start"
-              } gap-[4rem]`}
+              key={v.id}
+              /*  ▼ only change: items-start instead of items-end  */
+              className={`w-full flex flex-col lg:justify-between items-start mb-[4rem] gap-[4rem] ${
+                idx % 2 === 0 ? "md:flex-row" : "md:flex-row-reverse"
+              }`}
             >
+              {/* portrait */}
               <ImageFrame
-                image={volunteer.image}
-                name={volunteer.name}
-                lastName={volunteer.lastName}
-                index={index}
+                image={v.image}
+                name={v.name}
+                lastName={v.lastName}
+                index={idx}
               />
+
+              {/* text column */}
               <div className="flex flex-col gap-[1rem] w-full md:w-[45%] max-w-[500px] lg:mt-[1.5rem]">
-                <h6 className="font-bold text-[2.5rem] leading-8">{"Meet"}</h6>
-                <h6 className="font-bold text-[2.5rem] leading-8 ">
-                  {volunteer.name}
-                </h6>
-                <p className="text-[1.25rem] mt-4">{volunteer.content1}</p>
-                {volunteer.content2 && (
-                  <p className="text-[1.25rem] mt-4">{volunteer.content2}</p>
-                )}
-                {volunteer.content3 && (
-                  <p className="text-[1.25rem] mt-4">{volunteer.content3}</p>
-                )}
+                <h6 className="font-bold text-[2.5rem] leading-8">Meet</h6>
+                <h6 className="font-bold text-[2.5rem] leading-8">{v.name}</h6>
+
                 <p className="text-[1.25rem] mt-4">
-                  {volunteer.signatureLine1}
+                  {isExpanded ? fullText : shortText}
+                  {fullText.length > charLimit && (
+                    <button
+                      onClick={() => toggleExpand(v.id)}
+                      className="ml-2 text-primary500 font-semibold hover:underline focus:outline-none"
+                    >
+                      {isExpanded ? "Read Less" : "Read More"}
+                    </button>
+                  )}
                 </p>
-                <p className="text-[1.25rem] leading-[0px]">
-                  {volunteer.signatureLine2}
-                </p>
+
+                <p className="text-[1.25rem] mt-4">{v.signatureLine1}</p>
+                <p className="text-[1.25rem] leading-none">{v.signatureLine2}</p>
               </div>
             </div>
           );

--- a/src/Pages/Homepage/Cards/Cards.jsx
+++ b/src/Pages/Homepage/Cards/Cards.jsx
@@ -4,7 +4,6 @@ import { useNavigate } from "react-router-dom";
 import slider1 from "../../../assets/images/card1.jpg";
 import slider2 from "../../../assets/images/card2.jpg";
 import slider3 from "../../../assets/images/card3.jpg";
-import greaterImg from "../../../assets/images/greater.png";
 
 import testimonialImg21 from "../../../assets/images/Get-Involved/Volunteer2.png";
 import testimonialImg22 from "../../../assets/images/Get-Involved/Eric.png";
@@ -43,7 +42,7 @@ const testimonial = [
     lastName: "Stanciu",
     image: testimonialImg21,
     content1:
-      "“KeelWorks gave my resume legitimate experience. I learned to storyboard and build projects in Captivate using assets created in Photoshop and Audition. Now, I am a Senior Program Manager at Amazon. My success is the product of several career steps, all of which began with my practice in instructional design - and that started with KeelWorks.”",
+      "“KeelWorks gave my resume legitimate experience. I learned to storyboard and build projects in Captivate using assets created in Photoshop and Audition. Now, I am a Senior Program Manager at Amazon. My success is the product of several career steps, all of which began with my practice in instructional design – and that started with KeelWorks.”",
     designation: "Senior Program Manager at Amazon"
   },
   {
@@ -65,13 +64,13 @@ const Cards = () => {
 
   return (
     <div className="w-screen">
-      {/* ──────────────── Top Intro Copy ──────────────── */}
+      {/* ─────────── Top Intro Copy ─────────── */}
       <div className="w-screen flex justify-center bg-grey200">
         <div className="w-full max-w-[3000px]">
           <div className="lg:mx-[8rem] md:mx-[2rem] mx-[1rem]">
             <p className="lg:text-[2.68rem] md:text-[2.25rem] sm:text-[1.875rem] text-[1.5rem] font-bold leading-relaxed lg:pt-[8rem] sm:pt-[6rem] pt-[4rem]">
               Too many, eager to work,{" "}
-              <span className="text-primary500"> lack the required skills </span>
+              <span className="text-primary500">lack the required skills</span>{" "}
               to qualify for sustaining employment.
             </p>
           </div>
@@ -84,33 +83,34 @@ const Cards = () => {
         </div>
       </div>
 
-      {/* ─────────────── KeelWorks Solutions ─────────────── */}
-      <div className="w-screen flex flex-col justify-center items-center bg-white lg:h-screen">
-        <div className="w-full flex justify-center pt-[3.5rem] pb-10">
-          <p className="text-4xl md:text-5xl lg:text-6xl font-bold ml-4 md:ml-0">
-            The <span className="text-primary500">KeelWorks </span>Solutions
-          </p>
-        </div>
+      {/* ─────────── KeelWorks Solutions ─────────── */}
+      <div className="w-screen flex flex-col items-center bg-white lg:h-screen">
+        <h2 className="w-full text-center text-4xl md:text-5xl lg:text-6xl font-bold pt-[3.5rem] pb-10">
+          The <span className="text-primary500">KeelWorks </span>Solutions
+        </h2>
 
-        {/* ===== MOBILE IMAGE CARDS (< md) ===== */}
-        <div className="md:hidden w-full max-w-[3000px] flex flex-col gap-8 px-4">
+        {/* === MOBILE & TABLET ( < 1280 px ) === */}
+        <div className="
+            xl:hidden                              /* hide on real desktops */
+            w-full max-w-[3000px]
+            grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3
+            gap-8 px-4
+          ">
           {solutions.map(sol => (
             <div
               key={sol.id}
               onClick={() => navigate(`/oursolutions#${sol.id}`)}
               className="relative overflow-hidden rounded-xl shadow-lg"
             >
-              <img
-                src={sol.img}
-                alt=""
-                className="w-full h-full object-cover rounded-xl"
-              />
+              <img src={sol.img} alt="" className="w-full h-full object-cover rounded-xl" />
 
               {/* blurred gradient overlay */}
-              <div className="absolute bottom-0 w-full 
-                              bg-gradient-to-t from-black/70 to-transparent 
-                              backdrop-blur-sm
-                              text-white px-5 py-5">
+              <div className="
+                  absolute bottom-0 w-full
+                  bg-gradient-to-t from-black/70 to-transparent
+                  backdrop-blur-sm
+                  text-white px-5 py-5
+                ">
                 <h3 className="text-primary500 font-extrabold text-2xl mb-2">
                   {sol.title}
                 </h3>
@@ -120,9 +120,12 @@ const Cards = () => {
           ))}
         </div>
 
-
-        {/* ===== DESKTOP / TABLET GRID (≥ md) ===== */}
-        <div className="hidden md:grid w-full max-w-[3000px] grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+        {/* === DESKTOP ( ≥ 1280 px ) with hover overlay === */}
+        <div className="
+            hidden xl:grid
+            w-full max-w-[3000px]
+            grid-cols-3 gap-6
+          ">
           {solutions.map(sol => (
             <div
               key={sol.id}
@@ -131,84 +134,63 @@ const Cards = () => {
             >
               <img src={sol.img} alt="" className="w-full h-full object-cover" />
 
-              {/* OUTER overlay (full height, transparent) */}
               <div className="absolute inset-0 flex flex-col justify-end">
-
-                {/* INNER wrapper — collapsed bar grows on hover */}
                 <div className="
-                      w-full bg-gradient-to-t from-black/90 to-transparent
-                      text-white px-5 py-4
-                      h-[70px] lg:group-hover:h-full
-                      overflow-hidden                      /* hide text until expanded */
-                      transition-all duration-500
-                    ">
-                  <h3 className="text-primary500 font-extrabold text-3xl md:text-4xl">
-                    {sol.title}
-                  </h3>
+                    w-full bg-gradient-to-t from-black/90 to-transparent
+                    text-white px-5 py-4
+                    h-[70px] group-hover:h-[40%]
+                    overflow-hidden transition-all duration-500
+                  ">
+                  <h3 className="text-primary500 font-bold text-5xl">{sol.title}</h3>
 
                   <p className="
-                        mt-3 leading-relaxed text-base md:text-lg
-                        opacity-0 translate-y-4
-                        lg:group-hover:opacity-100 lg:group-hover:translate-y-0
-                        transition-all duration-500
-                      ">
+                      mt-3 font-medium text-[1.625rem] leading-relaxed
+                      opacity-0 translate-y-4
+                      group-hover:opacity-100 group-hover:translate-y-0
+                      transition-all duration-500
+                    ">
                     {sol.desc}
                   </p>
                 </div>
               </div>
-
             </div>
           ))}
         </div>
       </div>
 
-      {/* ─────────────── Testimonial Section ─────────────── */}
-      <div className="w-full flex flex-col justify-center items-center bg-white py-16">
-        <h2 className="text-4xl md:text-5xl font-bold text-center text-primary500 mb-12">
+      {/* ─────────── Testimonials ─────────── */}
+      <div className="w-full flex flex-col items-center bg-white py-16">
+        <h2 className="text-4xl md:text-5xl font-bold text-primary500 mb-12">
           Testimonials
         </h2>
 
-        <div className="max-w-5xl w-full px-4 mx-auto flex flex-col md:flex-row justify-center items-center gap-12">
-          {testimonial.map(
-            ({ id, name, lastName, image, content1, designation }) => (
-              <div key={id} className="flex flex-col items-center text-center">
-                {/* image with yellow frame */}
-                <div className="relative w-[250px] h-[250px] mb-4">
-                  <div className="absolute -top-3 -left-3 w-full h-full border-4 border-yellow-500"></div>
-                  <img
-                    src={image}
-                    alt={`${name} ${lastName}`}
-                    className="w-full h-full object-cover rounded-lg"
-                  />
-                </div>
-
-                <p className="font-bold text-lg">
-                  {name} {lastName}
-                </p>
-                <p className="text-gray-600">{designation}</p>
-                <TestimonialText content={content1} charLimit={188} />
+        <div className="max-w-5xl w-full px-4 mx-auto flex flex-col md:flex-row justify-center items-center gap-12 md:mx-auto md:w-fit">
+          {testimonial.map(t => (
+            <div key={t.id} className="flex flex-col items-center text-center">
+              <div className="relative w-[250px] h-[250px] mb-4">
+                <div className="absolute -top-3 -left-3 w-full h-full border-4 border-yellow-500" />
+                <img src={t.image} alt="" className="w-full h-full object-cover rounded-lg" />
               </div>
-            )
-          )}
+
+              <p className="font-bold text-lg">{t.name} {t.lastName}</p>
+              <p className="text-gray-600">{t.designation}</p>
+              <TestimonialText content={t.content1} charLimit={188} />
+            </div>
+          ))}
         </div>
 
-        <a
-          href="https://keelworks.org/getinvolved"
-          target="_blank"
-          rel="noopener noreferrer"
-        >
+        <a href="https://keelworks.org/getinvolved" target="_blank" rel="noopener noreferrer">
           <button className="mt-8 border-2 border-yellow-500 text-yellow-500 px-6 py-3 rounded-lg text-lg font-semibold hover:bg-yellow-500 hover:text-white transition">
             Learn More
           </button>
         </a>
       </div>
 
-      {/* ─────────────── Bottom CTA Copy ─────────────── */}
+      {/* ─────────── Bottom CTA ─────────── */}
       <div className="w-full bg-grey200 flex justify-center">
-        <div className="max-w-[3000px] mx-[1rem] md:mx-[2rem] lg:mx-[8rem]">
-          <p className="text-[2rem] font-bold leading-relaxed py-[8rem] md:text-[2.68rem]">
-            If you believe in our mission to get people to work, we need your
-            partnership.
+        <div className="max-w-[3000px] mx-4 md:mx-8 lg:mx-[8rem]">
+          <p className="text-[2rem] md:text-[2.68rem] font-bold leading-relaxed py-[8rem]">
+            If you believe in our mission to get people to work, we need your partnership.
           </p>
         </div>
       </div>
@@ -216,7 +198,7 @@ const Cards = () => {
   );
 };
 
-/* ===== Helper for expandable testimonial copy ===== */
+/* helper for expandable testimonial copy */
 const TestimonialText = ({ content, charLimit }) => {
   const [isExpanded, setIsExpanded] = useState(false);
   const showToggle = content.length > charLimit;

--- a/src/Pages/Homepage/Cards/Cards.jsx
+++ b/src/Pages/Homepage/Cards/Cards.jsx
@@ -6,6 +6,8 @@ import { Link, useNavigate } from "react-router-dom";
 import testimonialImg21 from "../../../assets/images/Get-Involved/Volunteer2.png";
 import testimonialImg22 from "../../../assets/images/Get-Involved/Eric.png";
 import ImageFrame from "../../../Components/ImageFrame/ImageFrame";
+import { useState } from "react";
+
 
 const testimonial = [
   {
@@ -179,7 +181,8 @@ const Cards = () => {
             {/* Testimonial text */}
             <p className="font-bold text-lg">{name} {lastName}</p>
             <p className="text-gray-600">{designation}</p>
-            <p className="text-gray-700 mt-2 px-4 max-w-xs">{content1}</p>
+            {/* <p className="text-gray-700 mt-2 px-4 max-w-xs">{content1}</p> */}
+            <TestimonialText content={content1} charLimit={188} />
           </div>
         ))}
       </div>
@@ -204,4 +207,26 @@ const Cards = () => {
     </div>
   );
 };
+const TestimonialText = ({ content, charLimit }) => {
+  const [isExpanded, setIsExpanded] = useState(false);
+  const toggleExpand = () => setIsExpanded(!isExpanded);
+
+  const showToggle = content.length > charLimit;
+  const displayText = isExpanded ? content : content.slice(0, charLimit) + (showToggle ? "..." : "");
+
+  return (
+    <p className="text-gray-700 mt-2 px-4 max-w-xs">
+      {displayText}
+      {showToggle && (
+        <button
+          onClick={toggleExpand}
+          className="ml-2 text-primary500 font-semibold hover:underline focus:outline-none"
+        >
+          {isExpanded ? "Read Less" : "Read More"}
+        </button>
+      )}
+    </p>
+  );
+};
+
 export default Cards;

--- a/src/Pages/Homepage/Cards/Cards.jsx
+++ b/src/Pages/Homepage/Cards/Cards.jsx
@@ -1,13 +1,40 @@
+import { useState } from "react";
+import { useNavigate } from "react-router-dom";
+
 import slider1 from "../../../assets/images/card1.jpg";
 import slider2 from "../../../assets/images/card2.jpg";
 import slider3 from "../../../assets/images/card3.jpg";
 import greaterImg from "../../../assets/images/greater.png";
-import { Link, useNavigate } from "react-router-dom";
+
 import testimonialImg21 from "../../../assets/images/Get-Involved/Volunteer2.png";
 import testimonialImg22 from "../../../assets/images/Get-Involved/Eric.png";
-import ImageFrame from "../../../Components/ImageFrame/ImageFrame";
-import { useState } from "react";
 
+/* ----------------------------------------------------------
+   SHARED DATA
+---------------------------------------------------------- */
+const solutions = [
+  {
+    id: "keelMaster",
+    title: "KeelMaster",
+    img: slider1,
+    desc:
+      "A three‑phase approach to support the most challenged unemployed and under‑employed individuals mitigating barriers to sustainable employment."
+  },
+  {
+    id: "keelMate",
+    title: "KeelMate",
+    img: slider2,
+    desc:
+      "Designed to bridge the gap for participants with insufficient education and/or experience in our supported fields; better positioning them for employment and growth."
+  },
+  {
+    id: "keelWings",
+    title: "KeelWings",
+    img: slider3,
+    desc:
+      "Assists graduates breakthrough the “lack of experience” conundrum while providing them valuable employment coaching."
+  }
+];
 
 const testimonial = [
   {
@@ -16,8 +43,8 @@ const testimonial = [
     lastName: "Stanciu",
     image: testimonialImg21,
     content1:
-      '“KeelWorks gave my resume legitimate experience. I learned to storyboard and build projects in Captivate using assets created in Photoshop and Audition. Now, I am a Senior Program Manager at Amazon. My success is the product of several career steps, all of which began with my practice in instructional design - and that started with KeelWorks.”',
-    designation: "Senior Program Manager at Amazon",
+      "“KeelWorks gave my resume legitimate experience. I learned to storyboard and build projects in Captivate using assets created in Photoshop and Audition. Now, I am a Senior Program Manager at Amazon. My success is the product of several career steps, all of which began with my practice in instructional design - and that started with KeelWorks.”",
+    designation: "Senior Program Manager at Amazon"
   },
   {
     id: 2,
@@ -25,201 +52,185 @@ const testimonial = [
     lastName: "Halterman",
     image: testimonialImg22,
     content1:
-      '“I have been trying to transition out of the classroom and into instructional design for a while now, and I was fortunate enough to find this internship opportunity. From the moment I joined, I was given valuable resources to help guide not only my processes, but my thinking.”',
-    designation: "Instructional Designer",
+      "“I have been trying to transition out of the classroom and into instructional design for a while now, and I was fortunate enough to find this internship opportunity. From the moment I joined, I was given valuable resources to help guide not only my processes, but my thinking.”",
+    designation: "Instructional Designer"
   }
-]
+];
 
+/* ==========================================================
+   MAIN COMPONENT
+========================================================== */
 const Cards = () => {
   const navigate = useNavigate();
+
   return (
     <div className="w-screen">
-      {/* ********************* Text at the Top of Cards ********************* */}
+      {/* ──────────────── Top Intro Copy ──────────────── */}
       <div className="w-screen flex justify-center bg-grey200">
         <div className="w-full max-w-[3000px]">
           <div className="lg:mx-[8rem] md:mx-[2rem] mx-[1rem]">
-            <p className="lg:text-[2.68rem] md:text-[2.25rem] sm:text-[1.875rem] text-[1.5rem] font-bold leading-relaxed lg:pt-[8rem] sm:pt-[6rem] pt-[4rem] ">
+            <p className="lg:text-[2.68rem] md:text-[2.25rem] sm:text-[1.875rem] text-[1.5rem] font-bold leading-relaxed lg:pt-[8rem] sm:pt-[6rem] pt-[4rem]">
               Too many, eager to work,{" "}
-              <span className="text-primary500 "> lack the required skills </span>to qualify for sustaining employment.
+              <span className="text-primary500"> lack the required skills </span>
+              to qualify for sustaining employment.
             </p>
           </div>
           <div className="w-full">
             <p className="lg:text-[2.68rem] md:text-[2.25rem] text-[2.5rem] font-bold leading-relaxed lg:mx-[8rem] md:mx-[2rem] mx-[1rem] pt-10 lg:pb-[8rem] sm:pb-[6rem] pb-[4rem]">
-              If we can guide them, we can prepare them for that {" "}
-              {" "}
+              If we can guide them, we can prepare them for that{" "}
               <span className="text-primary500">sustaining employment.</span>
             </p>
           </div>
         </div>
       </div>
-      {/* ********************* 3 x Cards ********************* */}
-      <div className="w-screen flex flex-col justify-center items-center bg-white lg:h-screen ">
-        <div className="w-full flex justify-center pt-[3.5rem] pb-10 ">
-          <p className="text-4xl md:text-5xl lg:text-6xl font-bold ml-4 lg:ml-0 md:ml-0">
-            The <span className="text-primary500 ">KeelWorks </span>Solutions
+
+      {/* ─────────────── KeelWorks Solutions ─────────────── */}
+      <div className="w-screen flex flex-col justify-center items-center bg-white lg:h-screen">
+        <div className="w-full flex justify-center pt-[3.5rem] pb-10">
+          <p className="text-4xl md:text-5xl lg:text-6xl font-bold ml-4 md:ml-0">
+            The <span className="text-primary500">KeelWorks </span>Solutions
           </p>
         </div>
-        <div className="w-full max-w-[3000px] grid grid-cols-1 sm:grid-cols-1 md:grid-cols-2 lg:grid-cols-3 xl:grid-cols-3  sm:gap-2 gap-6 lg:h-4/5">
-          {/* ******** KeelMaster Card ********* */}
-          <div
-            className="overflow-hidden sm:m-2 md:m-4 lg:m-4 relative group  m-2 "
-            onClick={() => {
-              navigate("/oursolutions#keelMaster");
-            }}
-          >
-            <img src={slider1} alt="" className="w-full h-full object-cover" />
-            <div className="intro h-1/6 w-full sm:p-2 md:p-2 lg:p-2 text-white absolute bottom-0 lg:group-hover:h-4/5  md:group-hover:h-3/4 group-hover:h-3/5 group-hover:bottom-0 transition-all duration-500 group-hover:cursor-pointer backdrop-blur-lg bg-black bg-opacity-60">
-              <div
-                className="flex items-center justify-center"
-                style={{ margin: "20px 0" }}
-              >
-                <div className="flex items-center justify-start w-full">
-                  <h1 className="text-primary500 font-bold text-3xl sm:text-4xl md:text-4xl lg:text-4xl xl:text-5xl ml-4">
-                    KeelMaster
-                  </h1>
-                </div>
-              </div>
-              <div className="text-[1.5rem] custombp:text-[1.2rem]/[2rem] custombp2:text-[1.5rem]/[2.5rem] xl:text-[1.875rem] font-medium  m-4  opacity-0 transition-opacity duration-500 group-hover:opacity-100 group-hover:mt-2 sm:leading-relaxed md:leading-[2rem] [@media(min-height:800px)]:leading-[3rem]">
-                A three-phase approach to support the most challenged unemployed
-                and under-employed individuals mitigating barriers to
-                sustainable employment.
-                {/* <a href="" className="ml-2 underline text-primary500 hover:text-primary400">more</a> */}
-                <span className="inline-flex items-center ">
-                  <img src={greaterImg} alt="" className="w-5 h-5 ml-1" />
-                </span>
+
+        {/* ===== MOBILE IMAGE CARDS (< md) ===== */}
+        <div className="md:hidden w-full max-w-[3000px] flex flex-col gap-8 px-4">
+          {solutions.map(sol => (
+            <div
+              key={sol.id}
+              onClick={() => navigate(`/oursolutions#${sol.id}`)}
+              className="relative overflow-hidden rounded-xl shadow-lg"
+            >
+              <img
+                src={sol.img}
+                alt=""
+                className="w-full h-full object-cover rounded-xl"
+              />
+
+              {/* blurred gradient overlay */}
+              <div className="absolute bottom-0 w-full 
+                              bg-gradient-to-t from-black/70 to-transparent 
+                              backdrop-blur-sm
+                              text-white px-5 py-5">
+                <h3 className="text-primary500 font-extrabold text-2xl mb-2">
+                  {sol.title}
+                </h3>
+                <p className="text-base leading-relaxed">{sol.desc}</p>
               </div>
             </div>
-          </div>
-          {/* ******** KeelMate Card ********* */}
-          <div
-            className="overflow-hidden  sm:m-2 md:m-4 lg:m-4   relative group m-2"
-            onClick={() => {
-              navigate("/oursolutions#keelMate");
-            }}
-          >
-            <img src={slider2} alt="" className="w-full h-full object-cover" />
-            <div className="intro h-1/6 w-full sm:p-2 md:p-2 lg:p-2 text-white absolute bottom-0 lg:group-hover:h-4/5  md:group-hover:h-3/4 group-hover:h-3/5 group-hover:bottom-0 transition-all duration-500 group-hover:cursor-pointer backdrop-blur-lg bg-black bg-opacity-60">
-              <div
-                className="flex items-center justify-center"
-                style={{ margin: "20px 0" }}
-              >
-                <div className="flex items-center justify-start w-full">
-                  <h1 className="text-primary500 font-bold text-3xl sm:text-4xl md:text-4xl lg:text-4xl xl:text-5xl ml-4">
-                    KeelMate
-                  </h1>
+          ))}
+        </div>
+
+
+        {/* ===== DESKTOP / TABLET GRID (≥ md) ===== */}
+        <div className="hidden md:grid w-full max-w-[3000px] grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+          {solutions.map(sol => (
+            <div
+              key={sol.id}
+              onClick={() => navigate(`/oursolutions#${sol.id}`)}
+              className="relative overflow-hidden group cursor-pointer"
+            >
+              <img src={sol.img} alt="" className="w-full h-full object-cover" />
+
+              {/* OUTER overlay (full height, transparent) */}
+              <div className="absolute inset-0 flex flex-col justify-end">
+
+                {/* INNER wrapper — collapsed bar grows on hover */}
+                <div className="
+                      w-full bg-gradient-to-t from-black/90 to-transparent
+                      text-white px-5 py-4
+                      h-[70px] lg:group-hover:h-full
+                      overflow-hidden                      /* hide text until expanded */
+                      transition-all duration-500
+                    ">
+                  <h3 className="text-primary500 font-extrabold text-3xl md:text-4xl">
+                    {sol.title}
+                  </h3>
+
+                  <p className="
+                        mt-3 leading-relaxed text-base md:text-lg
+                        opacity-0 translate-y-4
+                        lg:group-hover:opacity-100 lg:group-hover:translate-y-0
+                        transition-all duration-500
+                      ">
+                    {sol.desc}
+                  </p>
                 </div>
               </div>
-              <div className="text-[1.5rem] custombp:text-[1.2rem]/[2rem] custombp2:text-[1.5rem]/[2.5rem] xl:text-[1.875rem] font-medium  m-4  opacity-0 transition-opacity duration-500 group-hover:opacity-100 group-hover:mt-2 sm:leading-relaxed md:leading-[2rem] [@media(min-height:800px)]:leading-[3rem]">
-                Designed to bridge the gap for participants with insufficient
-                education and/or experience in our supported fields; better
-                positioning them for employment and/or growth.
-                {/* <a href="" className="ml-2 underline text-primary500 hover:text-primary400">more</a> */}
-                <span className="inline-flex items-center">
-                  <img src={greaterImg} alt="" className="w-5 h-5 ml-1" />
-                </span>
-              </div>
+
             </div>
-          </div>
-          {/* ******** KeelWings Card ********* */}
-          <div
-            className="overflow-hidden sm:m-2 md:m-4 lg:m-4 relative group m-4"
-            onClick={() => {
-              navigate("/oursolutions#keelWings");
-            }}
-          >
-            <img src={slider3} alt="" className="w-full h-full object-cover" />
-            <div className="w-full h-1/6 sm:p-4 md:p-2 lg:p-2 text-white absolute bottom-0 lg:group-hover:h-4/5  group-hover:h-3/5 md:group-hover:h-3/5 group-hover:bottom-0 transition-all duration-500 group-hover:cursor-pointer backdrop-blur-lg bg-black bg-opacity-60 ">
-              <div
-                className="flex items-center justify-center"
-                style={{ margin: "20px 0" }}
-              >
-                <div className="flex items-center justify-start w-full">
-                  <h1 className="text-primary500 font-bold text-3xl sm:text-4xl md:text-4xl lg:text-4xl xl:text-5xl ml-4">
-                    KeelWings
-                  </h1>
-                  {/* <img
-                    src={greaterImg}
-                    alt=""
-                    className="mx-8 lg:w-6 lg:h-6 md:w-6 md:h-6 h-5 w-5 sm:w-6 sm:h-6 xl:w-8 xl:h-8"
-                  /> */}
-                </div>
-              </div>
-              <div className="text-[1.5rem] custombp:text-[1.2rem]/[2rem] custombp2:text-[1.5rem]/[2.5rem] xl:text-[1.875rem] font-medium  m-4  opacity-0 transition-opacity duration-500 group-hover:opacity-100 group-hover:mt-2 sm:leading-relaxed md:leading-[1.75rem] [@media(min-height:800px)]:leading-[3rem]">
-                Assists graduates breakthrough the “lack of experience”
-                conundrum while providing them valuable employment coaching.
-                <span className="inline-flex items-center">
-                  <img src={greaterImg} alt="" className="w- 5 h-5 ml-1" />
-                </span>
-              </div>
-            </div>
-          </div>
+          ))}
         </div>
       </div>
-      
-      {/* ********************* Testimonial Section ********************* */}
+
+      {/* ─────────────── Testimonial Section ─────────────── */}
       <div className="w-full flex flex-col justify-center items-center bg-white py-16">
-      {/* Section Title */}
-      <h2 className="text-4xl md:text-5xl font-bold text-center text-primary500 mb-12">
-        Testimonials
-      </h2>
+        <h2 className="text-4xl md:text-5xl font-bold text-center text-primary500 mb-12">
+          Testimonials
+        </h2>
 
-      {/* Testimonial Cards Container */}
-      <div className="max-w-5xl w-full px-4 mx-auto flex flex-col md:flex-row justify-center items-center gap-12">
-        {testimonial.map(({ id, name, lastName, image, content1, designation }, index) => (
-          <div key={id} className="flex flex-col items-center text-center">
-            {/* Image with Yellow Box Effect */}
-            <div className="relative w-[250px] h-[250px] mb-4">
-              {/* Yellow border box behind image */}
-              <div className="absolute -top-3 -left-3 w-full h-full border-4 border-yellow-500"></div>
-              {/* The actual image on the front */}
-              <img
-                src={image}
-                alt={`${name} ${lastName}`}
-                className="w-full h-full object-cover rounded-lg"
-              />
-            </div>
-            {/* Testimonial text */}
-            <p className="font-bold text-lg">{name} {lastName}</p>
-            <p className="text-gray-600">{designation}</p>
-            {/* <p className="text-gray-700 mt-2 px-4 max-w-xs">{content1}</p> */}
-            <TestimonialText content={content1} charLimit={188} />
-          </div>
-        ))}
-      </div>
+        <div className="max-w-5xl w-full px-4 mx-auto flex flex-col md:flex-row justify-center items-center gap-12">
+          {testimonial.map(
+            ({ id, name, lastName, image, content1, designation }) => (
+              <div key={id} className="flex flex-col items-center text-center">
+                {/* image with yellow frame */}
+                <div className="relative w-[250px] h-[250px] mb-4">
+                  <div className="absolute -top-3 -left-3 w-full h-full border-4 border-yellow-500"></div>
+                  <img
+                    src={image}
+                    alt={`${name} ${lastName}`}
+                    className="w-full h-full object-cover rounded-lg"
+                  />
+                </div>
 
-        {/* Learn More Button */}
-        <a href="https://keelworks.org/getinvolved" target="_blank" rel="noopener noreferrer">
+                <p className="font-bold text-lg">
+                  {name} {lastName}
+                </p>
+                <p className="text-gray-600">{designation}</p>
+                <TestimonialText content={content1} charLimit={188} />
+              </div>
+            )
+          )}
+        </div>
+
+        <a
+          href="https://keelworks.org/getinvolved"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
           <button className="mt-8 border-2 border-yellow-500 text-yellow-500 px-6 py-3 rounded-lg text-lg font-semibold hover:bg-yellow-500 hover:text-white transition">
             Learn More
           </button>
         </a>
       </div>
 
-
-      {/* ********************* Text at the Bottom of Cards ********************* */}
+      {/* ─────────────── Bottom CTA Copy ─────────────── */}
       <div className="w-full bg-grey200 flex justify-center">
         <div className="max-w-[3000px] mx-[1rem] md:mx-[2rem] lg:mx-[8rem]">
           <p className="text-[2rem] font-bold leading-relaxed py-[8rem] md:text-[2.68rem]">
-            If you believe in our mission to get people to work, we need your partnership.
+            If you believe in our mission to get people to work, we need your
+            partnership.
           </p>
         </div>
       </div>
     </div>
   );
 };
+
+/* ===== Helper for expandable testimonial copy ===== */
 const TestimonialText = ({ content, charLimit }) => {
   const [isExpanded, setIsExpanded] = useState(false);
-  const toggleExpand = () => setIsExpanded(!isExpanded);
-
   const showToggle = content.length > charLimit;
-  const displayText = isExpanded ? content : content.slice(0, charLimit) + (showToggle ? "..." : "");
+
+  const displayText = isExpanded
+    ? content
+    : content.slice(0, charLimit) + (showToggle ? "…" : "");
 
   return (
     <p className="text-gray-700 mt-2 px-4 max-w-xs">
       {displayText}
       {showToggle && (
         <button
-          onClick={toggleExpand}
+          onClick={() => setIsExpanded(!isExpanded)}
           className="ml-2 text-primary500 font-semibold hover:underline focus:outline-none"
         >
           {isExpanded ? "Read Less" : "Read More"}

--- a/src/Pages/OurSolutions/OurSolutions.jsx
+++ b/src/Pages/OurSolutions/OurSolutions.jsx
@@ -21,7 +21,7 @@ const OurSolutions = () => {
   }, [hash]);
   return (
     <div className="w-screen bg-grey300">
-      <BackToHome />
+      {/* <BackToHome /> */}
       <Hero />
       <KeelMaster />
       <KeelWings />


### PR DESCRIPTION
## ✨  What’s new
- **Home page – solution cards**
  - Re‑implemented hover overlay for desktop
  - Larger headline & body copy (matches legacy design)
  - Added blur‑gradient on hover + reduced overlay height 
  - Mobile / tablet (< lg) now uses single‑column image‑cards with static copy
  - Tablet grid (lg breakpoint) shows 3‑up layout

- **Hero “Get Involved” section**
  - “Volunteer” ⇢ **“Become a volunteer”** wording
  - “More Details” links now route to:
    - Donate → external Every.org URL
    - Volunteer → `#careers` in‑page anchor

- **Testimonials**
  - Added _read‑more_ toggle with 188‑char limit
  - Centered row on desktop via `md:w-fit md:mx-auto`
  - No layout changes for mobile

- **Careers page**
  - Char‑limit + read‑more for each job (220 chars)
  - Pagination scrolls to top on page change

- **Volunteers‑Say section**
  - Char‑limit + read‑more (300 chars)
  - Keeps portrait aligned on “Read More / Less”




