### PR TITLE
feat(newsletter): replace June 2025 page with new scoped HTML template; add fonts; fix nav overlap

### DIFF
--- a/index.html
+++ b/index.html
@@ -5,6 +5,19 @@
     <link rel="icon" type="image/svg+xml" href="/keelworks.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>KeelWorks</title>
+    <!-- Preconnect for Google Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+
+    <!-- Newsletter fonts -->
+    <link
+      href="https://fonts.googleapis.com/css?family=Lato:400,700&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css?family=Raleway:500,600&display=swap"
+      rel="stylesheet"
+    />
   </head>
   <body>
     <div id="root"></div>

--- a/src/Pages/Careers/Careers.jsx
+++ b/src/Pages/Careers/Careers.jsx
@@ -1,7 +1,7 @@
 import React, { useEffect, useState, useRef } from "react";
 import LoadingSpinner from "../../Components/KeelBot/LoadingSpinner/LoadingSpinner";
 
-const charLimit = 220; // change if you want a different truncate length
+const charLimit = 2000; // change if you want a different truncate length
 
 /* ────────────────────────────────────────────────────────── */
 const Careers = () => {

--- a/src/Pages/Homepage/Cards/Cards.jsx
+++ b/src/Pages/Homepage/Cards/Cards.jsx
@@ -1,10 +1,6 @@
 import { useState } from "react";
 import { useNavigate } from "react-router-dom";
 
-import slider1 from "../../../assets/images/card1.jpg";
-import slider2 from "../../../assets/images/card2.jpg";
-import slider3 from "../../../assets/images/card3.jpg";
-
 import testimonialImg21 from "../../../assets/images/Get-Involved/Volunteer2.png";
 import testimonialImg22 from "../../../assets/images/Get-Involved/Eric.png";
 
@@ -15,24 +11,21 @@ const solutions = [
   {
     id: "keelMaster",
     title: "KeelMaster",
-    img: slider1,
     desc:
-      "A three‑phase approach to support the most challenged unemployed and under‑employed individuals mitigating barriers to sustainable employment."
+      "A three-phase approach to support the most challenged unemployed and under-employed individuals mitigating barriers to sustainable employment.",
   },
   {
     id: "keelMate",
     title: "KeelMate",
-    img: slider2,
     desc:
-      "Designed to bridge the gap for participants with insufficient education and/or experience in our supported fields; better positioning them for employment and growth."
+      "Designed to bridge the gap for participants with insufficient education and/or experience in our supported fields; better positioning them for employment and growth.",
   },
   {
     id: "keelWings",
     title: "KeelWings",
-    img: slider3,
     desc:
-      "Assists graduates breakthrough the “lack of experience” conundrum while providing them valuable employment coaching."
-  }
+      "Assists graduates breakthrough the “lack of experience” conundrum while providing them valuable employment coaching.",
+  },
 ];
 
 const testimonial = [
@@ -42,8 +35,8 @@ const testimonial = [
     lastName: "Stanciu",
     image: testimonialImg21,
     content1:
-      "“KeelWorks gave my resume legitimate experience. I learned to storyboard and build projects in Captivate using assets created in Photoshop and Audition. Now, I am a Senior Program Manager at Amazon. My success is the product of several career steps, all of which began with my practice in instructional design – and that started with KeelWorks.”",
-    designation: "Senior Program Manager at Amazon"
+      "“KeelWorks gave my resume legitimate experience. I learned to storyboard and build projects in Captivate using assets created in Photoshop and Audition. Now, I am a Senior Program Manager at Amazon. My success is the product of several career steps, all of which began with my practice in instructional design – and that started with KeelWorks.”",
+    designation: "Senior Program Manager at Amazon",
   },
   {
     id: 2,
@@ -52,8 +45,8 @@ const testimonial = [
     image: testimonialImg22,
     content1:
       "“I have been trying to transition out of the classroom and into instructional design for a while now, and I was fortunate enough to find this internship opportunity. From the moment I joined, I was given valuable resources to help guide not only my processes, but my thinking.”",
-    designation: "Instructional Designer"
-  }
+    designation: "Instructional Designer",
+  },
 ];
 
 /* ==========================================================
@@ -83,77 +76,33 @@ const Cards = () => {
         </div>
       </div>
 
-      {/* ─────────── KeelWorks Solutions ─────────── */}
-      <div className="w-screen flex flex-col items-center bg-white lg:h-screen">
+      {/* ─────────── KeelWorks Solutions (Text-only Cards) ─────────── */}
+      <div className="w-screen flex flex-col items-center bg-white">
         <h2 className="w-full text-center text-4xl md:text-5xl lg:text-6xl font-bold pt-[3.5rem] pb-10">
           The <span className="text-primary500">KeelWorks </span>Solutions
         </h2>
 
-        {/* === MOBILE & TABLET ( < 1280 px ) === */}
-        <div className="
-            xl:hidden                              /* hide on real desktops */
-            w-full max-w-[3000px]
-            grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3
-            gap-8 px-4
-          ">
-          {solutions.map(sol => (
-            <div
+        <div className="w-full max-w-[3000px] grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8 px-4 lg:px-[8rem]">
+          {solutions.map((sol) => (
+            <button
               key={sol.id}
               onClick={() => navigate(`/oursolutions#${sol.id}`)}
-              className="relative overflow-hidden rounded-xl shadow-lg"
+              className="text-left rounded-xl border border-teal-400 bg-white p-6 shadow-sm transition hover:-translate-y-0.5 hover:shadow-md focus:outline-none focus:ring-2 focus:ring-teal-500"
             >
-              <img src={sol.img} alt="" className="w-full h-full object-cover rounded-xl" />
+              <h3 className="text-3xl md:text-[2.1rem] font-semibold text-fontPrimary">
+                {sol.title}
+              </h3>
 
-              {/* blurred gradient overlay */}
-              <div className="
-                  absolute bottom-0 w-full
-                  bg-gradient-to-t from-black/70 to-transparent
-                  backdrop-blur-sm
-                  text-white px-5 py-5
-                ">
-                <h3 className="text-primary500 font-extrabold text-2xl mb-2">
-                  {sol.title}
-                </h3>
-                <p className="text-base leading-relaxed">{sol.desc}</p>
-              </div>
-            </div>
-          ))}
-        </div>
+              <div className="my-4 h-px w-24 bg-fontPrimary/70" />
 
-        {/* === DESKTOP ( ≥ 1280 px ) with hover overlay === */}
-        <div className="
-            hidden xl:grid
-            w-full max-w-[3000px]
-            grid-cols-3 gap-6
-          ">
-          {solutions.map(sol => (
-            <div
-              key={sol.id}
-              onClick={() => navigate(`/oursolutions#${sol.id}`)}
-              className="relative overflow-hidden group cursor-pointer"
-            >
-              <img src={sol.img} alt="" className="w-full h-full object-cover" />
+              <p className="text-greyCustom leading-relaxed">
+                {sol.desc}
+              </p>
 
-              <div className="absolute inset-0 flex flex-col justify-end">
-                <div className="
-                    w-full bg-gradient-to-t from-black/90 to-transparent
-                    text-white px-5 py-4
-                    h-[70px] group-hover:h-[40%]
-                    overflow-hidden transition-all duration-500
-                  ">
-                  <h3 className="text-primary500 font-bold text-5xl">{sol.title}</h3>
-
-                  <p className="
-                      mt-3 font-medium text-[1.625rem] leading-relaxed
-                      opacity-0 translate-y-4
-                      group-hover:opacity-100 group-hover:translate-y-0
-                      transition-all duration-500
-                    ">
-                    {sol.desc}
-                  </p>
-                </div>
-              </div>
-            </div>
+              <span className="mt-6 inline-block font-semibold text-teal-700 hover:underline">
+                Learn More
+              </span>
+            </button>
           ))}
         </div>
       </div>
@@ -165,21 +114,31 @@ const Cards = () => {
         </h2>
 
         <div className="max-w-5xl w-full px-4 mx-auto flex flex-col md:flex-row justify-center items-center gap-12 md:mx-auto md:w-fit">
-          {testimonial.map(t => (
+          {testimonial.map((t) => (
             <div key={t.id} className="flex flex-col items-center text-center">
               <div className="relative w-[250px] h-[250px] mb-4">
                 <div className="absolute -top-3 -left-3 w-full h-full border-4 border-yellow-500" />
-                <img src={t.image} alt="" className="w-full h-full object-cover rounded-lg" />
+                <img
+                  src={t.image}
+                  alt=""
+                  className="w-full h-full object-cover rounded-lg"
+                />
               </div>
 
-              <p className="font-bold text-lg">{t.name} {t.lastName}</p>
+              <p className="font-bold text-lg">
+                {t.name} {t.lastName}
+              </p>
               <p className="text-gray-600">{t.designation}</p>
               <TestimonialText content={t.content1} charLimit={188} />
             </div>
           ))}
         </div>
 
-        <a href="https://keelworks.org/getinvolved" target="_blank" rel="noopener noreferrer">
+        <a
+          href="https://keelworks.org/getinvolved"
+          target="_blank"
+          rel="noopener noreferrer"
+        >
           <button className="mt-8 border-2 border-yellow-500 text-yellow-500 px-6 py-3 rounded-lg text-lg font-semibold hover:bg-yellow-500 hover:text-white transition">
             Learn More
           </button>
@@ -190,7 +149,8 @@ const Cards = () => {
       <div className="w-full bg-grey200 flex justify-center">
         <div className="max-w-[3000px] mx-4 md:mx-8 lg:mx-[8rem]">
           <p className="text-[2rem] md:text-[2.68rem] font-bold leading-relaxed py-[8rem]">
-            If you believe in our mission to get people to work, we need your partnership.
+            If you believe in our mission to get people to work, we need your
+            partnership.
           </p>
         </div>
       </div>

--- a/src/Pages/Newsletters/June2025.jsx
+++ b/src/Pages/Newsletters/June2025.jsx
@@ -1,315 +1,346 @@
-import React from "react";
 import logo from "../../assets/images/Newsletters/June2025/keelworks_logo.jpg";
 import associateImg from "../../assets/images/Newsletters/June2025/associate.png";
 import diversityImg from "../../assets/images/Newsletters/June2025/diversity.png";
 import teamImg from "../../assets/images/Newsletters/June2025/team.png";
 import founder from "../../assets/images/Newsletters/MayNewsletter/Thomas-G.jpg";
 
+// src/Pages/Newsletters/June2025.jsx
+import { useEffect } from "react";
+
 export default function June2025Newsletter() {
-  // Helper: split text into paragraphs
-  function renderParagraphs(str, color = "#000") {
-    if (!str) return null;
-    return str.split(/\n\s*\n/).map((para, idx) => (
-      <p
-        key={idx}
-        style={{
-          color,
-          margin: 0,
-          marginBottom: 10,
-          lineHeight: 1.4,
-          textJustify: "inter-word",
-          hyphens: "auto",
-          textAlignLast: "left",
-        }}
-      >
-        {para.split("\n").map((line, i, arr) => (
-          <React.Fragment key={i}>
-            {line}
-            {i < arr.length - 1 && <br />}
-          </React.Fragment>
-        ))}
-      </p>
-    ));
-  }
+  useEffect(() => {
+    document.title = "KeelWorks – June 2025 Newsletter";
+  }, []);
+
+  // NOTE: Add these to public/index.html (or Vite's index.html) <head>:
+  // <link href="https://fonts.googleapis.com/css?family=Lato:400,700&display=swap" rel="stylesheet" />
+  // <link href="https://fonts.googleapis.com/css?family=Raleway:500,600&display=swap" rel="stylesheet" />
+
+  const html = `
+    <style>
+      /* Scoped to .kw-newsletter to avoid global CSS leaks */
+      .kw-newsletter, .kw-newsletter table, .kw-newsletter td {
+        margin: 0;
+        padding: 0;
+        width: 100% !important;
+        -webkit-text-size-adjust: 100%;
+        overflow-x: hidden !important;
+      }
+      .kw-newsletter img {
+        display: block;
+        max-width: 100% !important;
+        height: auto !important;
+      }
+      .kw-newsletter table {
+        border-collapse: collapse;
+        table-layout: fixed;
+        width: 100%;
+        word-break: break-word;
+      }
+      .kw-newsletter h1, .kw-newsletter h2, .kw-newsletter h3, .kw-newsletter p { margin: 0; padding: 0; }
+      .kw-newsletter .section-title {
+        font-family: 'Raleway', Arial, sans-serif;
+        font-size: 26px;
+        font-weight: 600;
+        margin-bottom: 12px;
+      }
+      .kw-newsletter .body-text {
+        font-size: 18px;
+        font-family: 'Lato', Arial, sans-serif;
+      }
+
+      /* ✅ Mobile adjustments */
+      @media only screen and (max-width: 600px) {
+        .kw-newsletter .container { width: 100% !important; max-width: 100% !important; }
+        .kw-newsletter .mobile-padding { padding: 12px !important; }
+        .kw-newsletter .section-title { font-size: 20px !important; }
+        .kw-newsletter .body-text { font-size: 14px !important; }
+        .kw-newsletter .mobile-header { font-size: 26px !important; }
+        .kw-newsletter .mobile-image {
+          width: 100% !important;
+          max-width: 100% !important;
+          height: auto !important;
+          display: block !important;
+          margin: 0 auto 15px !important;
+          float: none !important;
+        }
+        .kw-newsletter .mobile-button {
+          display: block !important;
+          width: 80% !important;
+          padding: 14px 18px !important;
+          font-size: 18px !important;
+          margin: 10px auto;
+        }
+        .kw-newsletter .stack-on-mobile { display: block !important; width: 100% !important; max-width: 100% !important; }
+        .kw-newsletter .footer-links, .kw-newsletter .footer-social {
+          display: block !important; width: 100% !important; text-align: center !important; padding: 10px 0 !important;
+        }
+        .kw-newsletter .footer-social img { margin: 0 8px !important; }
+        .kw-newsletter .desktop-padding { padding-left: 0 !important; }
+        .kw-newsletter .adjust-gap { padding-left: 1px !important; padding-right: 1px !important; }
+        .kw-newsletter .desktop-only { display: none !important; }
+        .kw-newsletter .mobile-only { display: table !important; }
+      }
+    </style>
+
+    <div class="kw-newsletter" style="background-color:#dcebf7; margin:0; padding:0;">
+      <table role="presentation" width="100%" cellpadding="0" cellspacing="0" border="0" style="padding:20px;">
+        <tr>
+          <td align="center">
+            <table role="presentation" class="container" width="100%" style="max-width:800px; background:#dcebf7; border-radius:8px; overflow:hidden; margin:0 auto;">
+
+              <!-- Header -->
+              <tr>
+                <td align="center" style="padding:20px;">
+                  <h1 class="mobile-header" style="font-family:'Raleway',Arial,sans-serif; font-size:38px; font-weight:600; color:#0a154f;">Monthly Newsletter</h1>
+                </td>
+              </tr>
+
+              <!-- Logo -->
+              <tr>
+                <td align="center" style="padding:0 20px 20px;">
+                  <img src="${logo}" alt="Keelworks Logo" style="max-width:350px; height:auto;" loading="lazy">
+                </td>
+              </tr>
+
+              <!-- Quote -->
+              <tr>
+                <td style="background:#394687; padding:24px; text-align:center; color:#fff;">
+                  <h2 class="section-title" style="font-family:'Raleway', Arial, sans-serif; font-size:24px; line-height:1.4; margin:0;">
+                    “When we are no longer able to change the situation, we are challenged to change ourselves.”<br><span style="display:block; text-align:center; font-size:18px; font-weight:normal; margin-top:8px;">- Viktor Frankl</span>
+                  </h2>
+                </td>
+              </tr>
+
+              <!-- Founder Message -->
+              <tr>
+                <td style="background:#869ba9; color:#fff; padding:28px;">
+                  <h2 class="section-title">Founder's Message for June 2025</h2>
+
+                  <!-- Desktop version -->
+                  <table class="desktop-only" role="presentation" width="100%" cellspacing="0" cellpadding="0" style="display:table;">
+                    <tr>
+                      <td style="padding:0;">
+                        <img
+                          src="${founder}"
+                          alt="Founder"
+                          style="float:right; border-radius:8px; width:220px; height:auto; margin-left:15px;"
+                          loading="lazy"
+                        />
+
+                        <p style="margin:0 0 12px; line-height:1.6; text-align:left; color:#fff; font-family:'Lato', Arial, sans-serif; font-size:18px; word-break:break-word;">
+                          Victor Frankl, with his holocaust experience has informed much of the philosophy that drives our KeelMaster core competencies. The quote above is relevant because change is what KeelWorks is all about. 
+                        </p>
+                        <p style="margin:0 0 12px; line-height:1.6; text-align:left; color:#fff; font-family:'Lato', Arial, sans-serif; font-size:18px; word-break:break-word;">
+                          On June 2nd, we marked the start of our 18th year. With over 1000 interns each year and the overwhelming majority leaving with jobs, we are making a difference. Most of you reading this have played a part in making this happen, and I am very grateful for your support.
+                        </p>
+                        <p style="margin:0 0 12px; line-height:1.6; text-align:left; color:#fff; font-family:'Lato', Arial, sans-serif; font-size:18px; word-break:break-word;">
+                          We continue to make progress building assets for KeelMaster program. That program has always been about getting the most challenged unemployed to work, but we also see it supporting at-risk high school students. We believe helping students this way can prevent the kind of issues leading to a need for KeelMaster later.
+                        </p>
+                        <p style="margin:0 0 12px; line-height:1.6; text-align:left; color:#fff; font-family:'Lato', Arial, sans-serif; font-size:18px; word-break:break-word;">
+                          I can’t end a monthly message without once again asking for your financial support. We sincerely appreciate every donation.
+                        </p>
+                      </td>
+                    </tr>
+                  </table>
+
+                  <!-- Mobile version -->
+                  <table class="mobile-only" role="presentation" width="100%" cellspacing="0" cellpadding="0" style="display:none;">
+                    <tr>
+                      <td style="text-align:center; padding-bottom:10px;">
+                        <img src="${founder}" alt="Founder" style="display:block; border-radius:8px; width:100%; max-width:220px; height:auto; margin:0 auto;" loading="lazy" />
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <p style="margin:0 0 12px; line-height:1.6; text-align:left; color:#fff; font-family:'Lato', Arial, sans-serif; font-size:18px; word-break:break-word;">
+                          Victor Frankl, with his holocaust experience has informed much of the phylosophy that drives our KeelMaster core competencies. The quote above is relevant because change is what KeelWorks is all about. 
+                        </p>
+                        <p style="margin:0 0 12px; line-height:1.6; text-align:left; color:#fff; font-family:'Lato', Arial, sans-serif; font-size:18px; word-break:break-word;">
+                          On June 2nd, we marked the start of our 18th year. With over 1000 interns each year and the overwhelming majority leaving with jobs, we are making a difference. Most of you reading this have played a part in making this happen, and I am very grateful for your support.
+                        </p>
+                        <p style="margin:0 0 12px; line-height:1.6; text-align:left; color:#fff; font-family:'Lato', Arial, sans-serif; font-size:18px; word-break:break-word;">
+                          We continue to make progress building assets for KeelMaster program. That program has always been about getting the most challenged unemployed to work, but we also see it supporting at-risk high school students. We believe helping students this way can prevent the kind of issues leading to a need for KeelMaster later.
+                        </p>
+                        <p style="margin:0 0 12px; line-height:1.6; text-align:left; color:#fff; font-family:'Lato', Arial, sans-serif; font-size:18px; word-break:break-word;">
+                          I can’t end a monthly message without once again asking for your financial support. We sincerely appreciate every donation.
+                        </p>
+                      </td>
+                    </tr>
+                  </table>
+                </td>
+              </tr>
+
+              <!-- Donate -->
+              <tr>
+                <td align="center" style="background:#5c98ad; padding:28px; color:#fff;">
+                  <h2 class="section-title">Your Support Makes a Difference</h2>
+                  <p class="body-text" style="margin:0 0 15px;">The work we do wouldn't be possible without your generosity.</p>
+                  <a href="https://www.every.org/keelworks-foundation" target="_blank" rel="noopener noreferrer" style="display:inline-block;background:#060e3a;color:#fff;text-decoration:none;padding:14px 40px;border-radius:30px;font-weight:bold;font-size:20px;" class="mobile-button">Donate Now</a>
+                </td>
+              </tr>
+
+              <!-- Diversity -->
+              <tr>
+                <td style="background:#446b92; color:#fff; padding:28px;">
+                  <h2 class="section-title">Diversity at Keelworks</h2>
+
+                  <!-- Desktop Version -->
+                  <table class="desktop-only" role="presentation" width="100%" cellspacing="0" cellpadding="0" style="display:table;">
+                    <tr>
+                      <td style="padding:0;">
+                        <img
+                          src="${diversityImg}"
+                          alt=""
+                          style="float:right; border-radius:10px; width:220px; height:auto; margin-left:15px;"
+                          loading="lazy"
+                        />
+
+                        <p style="margin:0 0 12px; line-height:1.6; text-align:left; color:#fff; font-family:'Lato', Arial, sans-serif; font-size:18px; word-break:break-word;">
+                          What sets me apart is my nontraditional educational journey. After pausing formal schooling in Bangladesh after 8th grade, I turned to self-directed learning while working remotely with international organizations like TED and KeelWorks. Now, as I prepare to study in the U.S. to earn both a high school diploma and an associate degree, I bring cultural adaptability, self-motivation, and a fresh, creative perspective to every team I join.
+                        </p>
+                        <p style="margin:0 0 12px; line-height:1.6; text-align:left; color:#fff; font-family:'Lato', Arial, sans-serif; font-size:18px; word-break:break-word;">
+                          At KeelWorks, I’ve always felt respected, supported, and truly welcomed. The open-minded team creates a safe, empowering space where I’m encouraged to share ideas and grow. It’s not about where you come from—it’s about what you bring to the table. There’s no jealousy, competition, or negativity—just trust, encouragement, and collaboration.
+                        </p>
+                      </td>
+                    </tr>
+                  </table>
+
+                  <!-- Mobile Version -->
+                  <table class="mobile-only" role="presentation" width="100%" cellspacing="0" cellpadding="0" style="display:none;">
+                    <tr>
+                      <td style="text-align:center; padding-bottom:10px;">
+                        <img src="${diversityImg}" alt="" style="display:block; border-radius:10px; width:100%; max-width:220px; margin:0 auto;" loading="lazy" />
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <p style="margin:0 0 12px; line-height:1.6; text-align:left; color:#fff; font-family:'Lato', Arial, sans-serif; font-size:18px; word-break:break-word;">
+                          What sets me apart is my nontraditional educational journey. After pausing formal schooling in Bangladesh after 8th grade, I turned to self-directed learning while working remotely with international organizations like TED and KeelWorks. Now, as I prepare to study in the U.S. to earn both a high school diploma and an associate degree, I bring cultural adaptability, self-motivation, and a fresh, creative perspective to every team I join.
+                        </p>
+                        <p style="margin:0 0 12px; line-height:1.6; text-align:left; color:#fff; font-family:'Lato', Arial, sans-serif; font-size:18px; word-break:break-word;">
+                          At KeelWorks, I’ve always felt respected, supported, and truly welcomed. The open-minded team creates a safe, empowering space where I’m encouraged to share ideas and grow. It’s not about where you come from—it’s about what you bring to the table. There’s no jealousy, competition, or negativity—just trust, encouragement, and collaboration.
+                        </p>
+                      </td>
+                    </tr>
+                  </table>
+                </td>
+              </tr>
+
+              <!-- Product -->
+              <tr>
+                <td style="background:#253c52; color:#fff; padding:28px;">
+                  <h2 class="section-title">Monthly Newsletter Application</h2>
+
+                  <p style="margin:0 0 12px; line-height:1.6; text-align:left; color:#fff; font-family:'Lato', Arial, sans-serif; font-size:18px; word-break:break-word;">
+                    Neeraj Bodhale, the Project Manager for the Monthly Newsletter App Team, shares his thoughts about the project.
+                  </p>
+                  <p style="margin:0 0 12px; line-height:1.6; text-align:left; color:#fff; font-family:'Lato', Arial, sans-serif; font-size:18px; word-break:break-word;">
+                    The Monthly Newsletter App will make the newsletter publication process quicker, easier, and more efficient.
+                  </p>
+                  <p style="margin:0 0 12px; line-height:1.6; text-align:left; color:#fff; font-family:'Lato', Arial, sans-serif; font-size:18px; word-break:break-word;">
+                    The first iteration has been completed with the rollout of the new template in the May edition of the Monthly Newsletter. The project is in the testing phase—evaluating functionality, gathering feedback, and making improvements. Future iterations will focus on enhancing user experience and expanding features.
+                  </p>
+                </td>
+              </tr>
+
+              <!-- Team -->
+              <tr>
+                <td style="background:#0a1d2f; color:#fff; padding:28px; text-align:left;">
+                  <h2 class="section-title" style="font-family:'Raleway', Arial, sans-serif; font-size:26px; font-weight:600; margin-bottom:12px; padding:0;">
+                    Monthly Newsletter Application Team
+                  </h2>
+                  <img src="${teamImg}" alt="Team" style="display:block; width:100%; max-width:90%; border-radius:10px; height:auto; margin-bottom:15px;" loading="lazy" />
+
+                  <p style="margin:0 0 12px; line-height:1.6; text-align:left; color:#fff; font-family:'Lato', Arial, sans-serif; font-size:18px; word-break:break-word;">
+                    Neeraj Bodhale, Monthly Newsletter Application team Project Manager:
+                  </p>
+                  <p style="margin:0 0 12px; line-height:1.6; text-align:left; color:#fff; font-family:'Lato', Arial, sans-serif; font-size:18px; word-break:break-word;">
+                    Proud to lead a creative and committed team. Their collaboration and ownership made the June newsletter a success. Grateful for everyone's effort!
+                  </p>
+                </td>
+              </tr>
+
+              <!-- Volunteer -->
+              <tr>
+                <td style="background:#5486b8; color:#fff; padding:28px;">
+                  <h2 class="section-title">Associate of the Month</h2>
+
+                  <!-- Desktop Version -->
+                  <table class="desktop-only" role="presentation" width="100%" cellspacing="0" cellpadding="0" style="display:table;">
+                    <tr>
+                      <td style="padding:0;">
+                        <img
+                          src="${associateImg}"
+                          alt=" Gauri Namdev Parab"
+                          style="float:right; border-radius:10px; width:220px; height:auto; margin-left:15px;"
+                          loading="lazy"
+                        />
+                        <h3 style="font-size:22px; margin-bottom:10px;"> Gauri Namdev Parab</h3>
+
+                        <p style="margin:0 0 12px; line-height:1.6; text-align:left; color:#fff; font-family:'Lato', Arial, sans-serif; font-size:18px; word-break:break-word;">
+                          Serving as a Marketing Associate here since August of '24, this experience has been enriching. Teaming with deeply committed associates in diverse roles has been challenging and exhilarating.
+                        </p>
+                        <p style="margin:0 0 12px; line-height:1.6; text-align:left; color:#fff; font-family:'Lato', Arial, sans-serif; font-size:18px; word-break:break-word;">
+                          Especially important is exposure to the strategic discussions and the application of my learning in real-world marketing. I’ve worked with talented people, applied skills learned in school, and learned from peers. I’ve gained confidence having accepted responsibility, successfully met those responsibilities, and enjoyed the respect of my peers. The range of tasks is exhilarating, and I love being at the center of such a diverse and competent team. I love being part of a team that depends on me and that I depend on.
+                        </p>
+                        <p style="margin:0 0 12px; line-height:1.6; text-align:left; color:#fff; font-family:'Lato', Arial, sans-serif; font-size:18px; word-break:break-word;">
+                          I am conscious of the many at this foundation worthy of this recognition. I am humbled and honored to be the recipient of this honor.
+                        </p>
+
+                        <strong style="display:block;margin-top:12px;font-size:18px;">Why  Gauri Namdev Parab?</strong>
+
+                        <p style="margin:0 0 12px; line-height:1.6; text-align:left; color:#fff; font-family:'Lato', Arial, sans-serif; font-size:18px; word-break:break-word;">
+                          Gauri is a dedicated and consistent performer. We depend on her for the monthly layout and content structuring for our newsletter. She is as regular as the sunrise and sunset and just as efficient. She quietly goes about her work, accepting revisions and critiques with equanimity. She makes us better and we could not accomplish our monthly newsletters without her.
+                        </p>
+                      </td>
+                    </tr>
+                  </table>
+
+                  <!-- Mobile Version -->
+                  <table class="mobile-only" role="presentation" width="100%" cellspacing="0" cellpadding="0" style="display:none;">
+                    <tr>
+                      <td style="text-align:center; padding-bottom:10px;">
+                        <img src="${associateImg}" alt=" Gauri Namdev Parab" style="display:block; border-radius:10px; width:100%; max-width:220px; margin:0 auto;" loading="lazy" />
+                      </td>
+                    </tr>
+                    <tr>
+                      <td>
+                        <h3 style="font-size:22px; text-align:center;"> Gauri Namdev Parab</h3>
+
+                        <p style="margin:0 0 12px; line-height:1.6; text-align:left; color:#fff; font-family:'Lato', Arial, sans-serif; font-size:18px; word-break:break-word;">
+                          Serving as a Marketing Associate here since August of '24, this experience has been enriching. Teaming with deeply committed associates in diverse roles has been challenging and exhilarating.
+                        </p>
+                        <p style="margin:0 0 12px; line-height:1.6; text-align:left; color:#fff; font-family:'Lato', Arial, sans-serif; font-size:18px; word-break:break-word;">
+                          Especially important is exposure to the strategic discussions and the application of my learning in real-world marketing. I’ve worked with talented people, applied skills learned in school, and learned from peers. I’ve gained confidence having accepted responsibility, successfully met those responsibilities, and enjoyed the respect of my peers. The range of tasks is exhilarating, and I love being at the center of such a diverse and competent team. I love being part of a team that depends on me and that I depend on.
+                        </p>
+                        <p style="margin:0 0 12px; line-height:1.6; text-align:left; color:#fff; font-family:'Lato', Arial, sans-serif; font-size:18px; word-break:break-word;">
+                          I am conscious of the many at this foundation worthy of this recognition. I am humbled and honored to be the recipient of this honor.
+                        </p>
+
+                        <strong style="display:block;margin-top:12px;font-size:18px;">Why  Gauri Namdev Parab?</strong>
+
+                        <p style="margin:0 0 12px; line-height:1.6; text-align:left; color:#fff; font-family:'Lato', Arial, sans-serif; font-size:18px; word-break:break-word;">
+                          Gauri is a dedicated and consistent performer. We depend on her for the monthly layout and content structuring for our newsletter. She is as regular as the sunrise and sunset and just as efficient. She quietly goes about her work, accepting revisions and critiques with equanimity. She makes us better and we could not accomplish our monthly newsletters without her.
+                        </p>
+                      </td>
+                    </tr>
+                  </table>
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+      </table>
+    </div>
+  `;
 
   return (
-    <div
-      className="bg-[#dcebf7] pt-16 pb-10 min-h-screen"
-      style={{ WebkitTextSizeAdjust: "100%" }}
-    >
-      {/* Header wrapper */}
-      <div className="max-w-full sm:max-w-[800px] mx-auto bg-[#bcf2fc] rounded-t-2xl overflow-hidden shadow-lg px-4 sm:px-6">
-        <div className="text-center py-5">
-          <h1
-            className="text-2xl sm:text-3xl md:text-4xl font-semibold text-[#0a154f]"
-            style={{ lineHeight: 1.2 }}
-          >
-            Monthly Newsletter
-          </h1>
-        </div>
-        <div className="px-4 pb-4">
-          <img
-            src={logo}
-            alt="Keelworks Foundation logo"
-            className="w-full max-w-[720px] mx-auto h-auto block"
-          />
-        </div>
-      </div>
+  <div className="pt-24 sm:pt-20 bg-[#dcebf7]">
+    <div dangerouslySetInnerHTML={{ __html: html }} />
+  </div>
+);
 
-      {/* Main content */}
-      <div className="max-w-full sm:max-w-[800px] mx-auto bg-gradient-to-b from-[#538699] to-[#263f48] p-4 sm:p-5 rounded-b-2xl shadow-lg mt-4">
-        {/* Quote */}
-        <div className="w-full bg-gradient-to-b from-[#0c1769c7] to-[#3828579e] rounded-lg p-6 sm:p-8 shadow-md mb-6">
-          <h2 className="text-xl sm:text-2xl font-medium text-white leading-tight">
-            “When we are no longer able to change the situation, we are
-            challenged to change ourselves.” – Viktor Frankl
-          </h2>
-        </div>
 
-        {/* Founder’s Message */}
-        <section className="flex flex-col md:flex-row-reverse bg-gradient-to-b from-[#869ba9] to-[#19394f] rounded-lg p-4 sm:p-5 shadow-md mb-6 text-white">
-          <img
-            src={founder}
-            alt="Portrait of the Founder"
-            className="w-full md:w-48 h-64 rounded-lg mb-4 md:mb-0 md:ml-4 border"
-          />
-          <div className="flex-1">
-            <h2 className="text-xl sm:text-2xl font-medium mb-3">
-              Founder’s Message for June 2025
-            </h2>
-            {renderParagraphs(
-              `Good June Folks! This month we are celebrating the start of our 18th year. With over 1000 interns each year and the overwhelming majority leaving with jobs, we are making a difference. Most of you reading this newsletter have played a part in making this happen, and I am very grateful for your support.
-
-We continue to make progress on the applications needed to allow us to launch the KeelMaster program. While that program has always been about getting the most career challenged people to work, we also see it supporting high school students.
-
-We are developing the curriculum and courses for the core competencies, and we are confident that teaching those core competencies will help them on their journey. challenged unemployed students to competencies self-identity, critical thinking, and assertiveness emotional intelligence.
-
-I can’t end a monthly message without once again asking for your financial support. We sincerely appreciate.`,
-              "#ffffff"
-            )}
-          </div>
-        </section>
-
-        {/* Donate CTA */}
-        <div className="w-full bg-gradient-to-r from-[#5d98ae] to-[#263f48] rounded-lg p-4 sm:p-5 text-center mb-6">
-          <h2 className="text-xl sm:text-2xl font-medium text-white mb-2">
-            Your support makes a difference
-          </h2>
-          <p className="text-sm sm:text-base text-white mb-3">
-            The work we do wouldn't be possible without the generosity of our
-            supporters.
-          </p>
-          <a
-            href="https://www.every.org/keelworks-foundation?utm_campaign=donate-link"
-            role="button"
-            aria-label="Donate to Keelworks Foundation"
-            className="inline-block px-5 py-2 sm:px-6 sm:py-3 bg-gradient-to-r from-[#060e3a] to-[#374269] rounded-full font-semibold text-base sm:text-xl text-white whitespace-nowrap"
-          >
-            Donate Now
-          </a>
-        </div>
-
-        {/* Diversity Section */}
-        <section className="flex flex-col md:flex-row bg-gradient-to-b from-[#5486b8b5] to-[#0a1d2fbf] rounded-lg p-4 sm:p-5 shadow-md mb-6 text-white">
-          <img
-            src={diversityImg}
-            alt="Photo of associate"
-            className="w-full md:w-48 h-64 mb-4 md:mb-0 md:mr-4 rounded-2xl border shadow-lg object-cover"
-          />
-          <div className="flex-1">
-            <h3 className="text-lg sm:text-xl font-semibold mb-2">
-              Fardinuzzaman Tajim
-            </h3>
-            {renderParagraphs(
-              `What sets me apart is my nontraditional educational journey. After pausing formal schooling in Bangladesh after 8th grade, I turned to self-directed learning while working remotely with international organizations like TED and KeelWorks. Now, as I prepare to study in the U.S. to earn both a high school diploma and an associate degree, I bring cultural adaptability, self-motivation, and a fresh, creative perspective to every team I join.
-
-At KeelWorks, I’ve always felt respected, supported, and truly welcomed. The open-minded team creates a safe, empowering space where I’m encouraged to share ideas and grow. It’s not about where you come from—it’s about what you bring to the table. There’s no jealousy, competition, or negativity—just trust, encouragement, and collaboration.
-`,
-              "#ffffff"
-            )}
-          </div>
-        </section>
-
-        {/* Product Section */}
-        <div className="w-full bg-gradient-to-b from-[#253c52] to-[#5486b8] rounded-lg p-4 sm:p-5 shadow-md mb-6 text-white">
-          <h2 className="text-xl sm:text-2xl font-medium mb-3">
-            Monthly Newsletter Application
-          </h2>
-          {renderParagraphs(
-            `Neeraj Bodhale, the Project Manager for the Monthly Newsletter App Team shares his thoughts about the project.
-
-The Monthly Newsletter App will make the newsletter publication process faster, easier, and more efficient.
-
-Currently, this process is each month.
-
-The Monthly Newsletter Application streamline process Once released, it will make publishing quicker, easier, and more.
-
-The first iteration has been completed with the rollout of the new template in the May edition of the Monthly Newsletter. The project is in the testing phase evaluating functionality, gathering feedback, and making improvements. Future iterations will focus on enhancing user experience and expanding features.`,
-            "#ffffff"
-          )}
-        </div>
-
-        {/* Team Section */}
-        <div className="w-full bg-gradient-to-b from-[#0a1d2f] to-[#5486b8] rounded-lg p-4 sm:p-5 shadow-md mb-6 text-white">
-          <h2 className="text-xl sm:text-2xl font-medium mb-3">
-            Monthly Newsletter Application Team
-          </h2>
-          <img
-            src={teamImg}
-            alt="Monthly Newsletter Application Team"
-            className="w-full h-auto rounded-lg mb-4"
-          />
-          {renderParagraphs(
-            `Neeraj Bodhale, Monthly Newsletter Application team project Manager:
-
-Proud to lead a creative and committed team. Their collaboration and ownership made the June newsletter a success. Grateful for everyone's effort!`,
-            "#ffffff"
-          )}
-        </div>
-
-        {/* Volunteer Spotlight */}
-        <section className="flex flex-col md:flex-row bg-gradient-to-b from-[#5486b8] to-[#0a1d2f] rounded-lg p-4 sm:p-5 shadow-md text-white">
-          <img
-            src={associateImg}
-            alt="Photo of Gauri Namdev Parab"
-            className="w-full md:w-48 h-64 mb-4 md:mb-0 md:mr-4 rounded-lg border"
-          />
-          <div className="flex-1">
-            <h2 className="text-xl sm:text-2xl font-medium mb-3">
-              Associate of the Month
-            </h2>
-            <h3 className="text-lg sm:text-xl font-semibold mb-2">
-              Gauri Namdev Parab
-            </h3>
-            {renderParagraphs(
-              `Serving as a Marketing Associate here since August of '24, this experience has been enriching. Teaming with deeply committed associates in diverse roles has been challenging and exhilarating.
-
-Especially important is exposure to the strategic discussions and the application of my learning in real-world marketing. I’ve worked with talented people, applied skills learned in school, and learned from peers. I’ve gained confidence having accepted responsibility, successfully met those responsibilities, and enjoyed the respect of my peers. The range of tasks is exhilarating, and I love being at the center of such a diverse and competent team. I love being part of a team that depends on me and that I depend on.
-
-I am conscious of the many at this foundation worthy of this recognition. I am humbled and honored to be the recipient of this honor.`,
-              "#ffffff"
-            )}
-            <strong className="block mt-3 mb-1">Why Gauri Namdev Parab?</strong>
-            {renderParagraphs(
-              `Gauri is a dedicated and consistent performer. We depend on her for the monthly layout and content structuring for our newsletter. She is as regular as the sunrise and sunset and just as efficient. She quietly goes about her work, accepting revisions and critiques with equanimity. She makes us better and we could not accomplish our monthly newsletters without her.`,
-              "#ffffff"
-            )}
-          </div>
-        </section>
-      </div>
-
-      {/* Footer */}
-      {/* <footer className="max-w-full sm:max-w-[800px] mx-auto bg-[#1f2e3d] text-white rounded-t-2xl p-4 sm:p-5 mt-6">
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-          <nav aria-label="Footer links">
-            <ul className="space-y-2 text-sm sm:text-base">
-              <li>
-                <a
-                  href="https://keelworks.org/about"
-                  className="text-white no-underline"
-                >
-                  About Us
-                </a>
-              </li>
-              <li>
-                <a
-                  href="https://keelworks.org/getinvolved"
-                  className="text-white no-underline"
-                >
-                  Get Involved
-                </a>
-              </li>
-              <li>
-                <a
-                  href="https://keelworks.org/oursolutions"
-                  className="text-white no-underline"
-                >
-                  Our Solutions
-                </a>
-              </li>
-              <li>
-                <a
-                  href="https://keelworks.org/blog"
-                  className="text-white no-underline"
-                >
-                  Blog
-                </a>
-              </li>
-              <li>
-                <a
-                  href="https://keelworks.org/success_stories"
-                  className="text-white no-underline"
-                >
-                  Success Stories
-                </a>
-              </li>
-              <li>
-                <a
-                  href="mailto:info@keelworks.org"
-                  className="text-white no-underline"
-                >
-                  Unsubscribe
-                </a>
-              </li>
-            </ul>
-          </nav>
-          <div className="text-right space-x-3">
-            <a
-              href="https://www.every.org/keelworks-foundation"
-              aria-label="Donate via Every.org"
-            >
-              <img
-                src="https://drive.usercontent.google.com/download?id=1u0TULL1XwZIhwPC084TzQeYYUYhe3RJH&export=view"
-                alt="Donate icon"
-                className="inline-block w-6 h-6 filter invert"
-              />
-            </a>
-            <a
-              href="https://www.linkedin.com/company/keelworks-foundation/"
-              aria-label="Keelworks LinkedIn page"
-            >
-              <img
-                src="https://drive.usercontent.google.com/download?id=155v9Havzd39zHRdKE1UdjvDhCYP7ODoZ&export=view"
-                alt="LinkedIn icon"
-                className="inline-block w-6 h-6 filter invert"
-              />
-            </a>
-            <a
-              href="https://www.facebook.com/TheKeelWorks"
-              aria-label="Keelworks Facebook page"
-            >
-              <img
-                src="https://drive.usercontent.google.com/download?id=1vMJ0Z7MSf_CJUqrKOOH5Z5yYhWk45fiE&export=view"
-                alt="Facebook icon"
-                className="inline-block w-6 h-6 filter invert"
-              />
-            </a>
-            <a
-              href="https://keelworks.org/contactus"
-              aria-label="Keelworks YouTube channel"
-            >
-              <img
-                src="https://drive.usercontent.google.com/download?id=16RUVQYX21WQ3HW0WoxJ8BeaTzHSOXZdT&export=view"
-                alt="YouTube icon"
-                className="inline-block w-6 h-6 filter invert"
-              />
-            </a>
-            <a
-              href="https://www.instagram.com/thekeelworks/"
-              aria-label="Keelworks Instagram profile"
-            >
-              <img
-                src="https://drive.usercontent.google.com/download?id=1ihpPifzkBKZaMLXwftBE1WExhp9bV8vE&export=view"
-                alt="Instagram icon"
-                className="inline-block w-6 h-6 filter invert"
-              />
-            </a>
-          </div>
-        </div>
-        <div className="text-center mt-4 text-xs sm:text-sm">
-          <p>© 2025 Keelworks. All rights reserved.</p>
-        </div>
-      </footer> */}
-    </div>
-  );
 }
+


### PR DESCRIPTION
## Summary
Replaces the old June 2025 newsletter React layout with the new HTML template rendered inside a scoped container to prevent global CSS bleed. Adds Google Fonts to `index.html` and fixes overlap with the fixed navbar.

## What changed
- `src/Pages/Newsletters/June2025.jsx`
  - Render newsletter via `dangerouslySetInnerHTML` inside `.kw-newsletter`
  - Scoped CSS inlined to `.kw-newsletter`
  - Imported local assets (logo, founder, diversity, team, associate)
  - Added top padding / wrapper spacing to avoid overlap with fixed navbar
- `index.html`
  - Added preconnect + Google Fonts (`Lato`, `Raleway`)

## Why
- Match the latest June template exactly
- Keep styles isolated from the rest of the site
- Ensure header isn’t hidden under the fixed navbar


