### PR TITLE
fix: use useLocation() for reliable GA pageview tracking

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,5 +1,5 @@
 import ReactGA from "react-ga4";
-const MEASUREMENT_ID = "G-K7FMRVVS50";
+export const MEASUREMENT_ID = "G-K7FMRVVS50";
 // **************** Components **************
 import SiteLayout from "./Components/SiteLayout/SiteLayout";
 import Error from "./Pages/Error/Error";
@@ -120,14 +120,6 @@ function App() {
   useEffect(() => {
     ReactGA.initialize(MEASUREMENT_ID);
   }, []);
-  useEffect(() => {
-    // Send a pageview event whenever the route changes
-    ReactGA.send({
-      hitType: "pageview",
-      page: location.pathname,
-      title: location.pathname, // Use the pathname as the title for simplicity
-    });
-  }, [location.pathname]);
   return (
     <main className=" overflow-x-hidden">
       <RouterProvider router={router} />

--- a/src/Components/SiteLayout/SiteLayout.jsx
+++ b/src/Components/SiteLayout/SiteLayout.jsx
@@ -1,10 +1,22 @@
 import Navbar from "../Navbar/Navbar";
 import Footer from "../Footer/Footer";
 
-import { Outlet, ScrollRestoration } from "react-router-dom";
+import { Outlet, ScrollRestoration, useLocation } from "react-router-dom";
 import KeelBot from "../KeelBot/KeelBot";
+import { useEffect } from "react";
+import ReactGA from "react-ga4";
 
 const SiteLayout = () => {
+  const location = useLocation();
+
+  useEffect(() => {
+    ReactGA.send({
+      hitType: "pageview",
+      page: location.pathname,
+      title: document.title,
+    });
+  }, [location.pathname]);
+
   return (
     <div>
       <Navbar />


### PR DESCRIPTION
## Summary
- Moves GA pageview tracking from `App.jsx` into `SiteLayout.jsx` where `useLocation()` is available inside the React Router context
- Previously used `window.location` (global), which only fired on initial load and missed SPA route changes
- Exports `MEASUREMENT_ID` from `App.jsx` for potential reuse

## Files Changed
- `src/App.jsx` — removed broken pageview `useEffect`, exported `MEASUREMENT_ID`
- `src/Components/SiteLayout/SiteLayout.jsx` — added `useLocation()` + `useEffect` to track every route change

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)