### PR TITLE
perf: lazy load all routes for faster initial bundle

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,29 +1,31 @@
 import ReactGA from "react-ga4";
 export const MEASUREMENT_ID = "G-K7FMRVVS50";
-// **************** Components **************
+// **************** Static imports (needed immediately) **************
 import SiteLayout from "./Components/SiteLayout/SiteLayout";
 import Error from "./Pages/Error/Error";
-import CommingSoon from "./Pages/ComingSoon/ComingSoon";
-import Home from "./Pages/Homepage/Home";
-import GetInvolved from "./Pages/GetInvolved/GetInvolved";
-import OurSolutions from "./Pages/OurSolutions/OurSolutions";
-import ContactUs from "./Pages/ContactUs/ContactUs";
-import AboutUs from "./Pages/AboutUs/AboutUs";
-import SuccessStories from "./Pages/SuccessStories/SuccessStories";
-import Blog from "./Pages/Blog/Blog_new";
-import Policy from "./Pages/Policy/Policy";
-import MayNewsletter from "./Pages/Newsletters/MayNewsletter";
-import June2025Newsletter from "./Pages/Newsletters/June2025";
-import Aug2025Newsletter from "./Pages/Newsletters/Aug2025";
-import October2025Newsletter from "./Pages/Newsletters/October2025";
-import November2025Newsletter from "./Pages/Newsletters/November2025";
-import December2025Newsletter from "./Pages/Newsletters/December2025";
-import January2026Newsletter from "./Pages/Newsletters/January2026";
-import February2026Newsletter from "./Pages/Newsletters/February2026";
+// **************** Lazy-loaded page components **************
+import { lazy } from "react";
+const CommingSoon            = lazy(() => import("./Pages/ComingSoon/ComingSoon"));
+const Home                   = lazy(() => import("./Pages/Homepage/Home"));
+const GetInvolved            = lazy(() => import("./Pages/GetInvolved/GetInvolved"));
+const OurSolutions           = lazy(() => import("./Pages/OurSolutions/OurSolutions"));
+const ContactUs              = lazy(() => import("./Pages/ContactUs/ContactUs"));
+const AboutUs                = lazy(() => import("./Pages/AboutUs/AboutUs"));
+const SuccessStories         = lazy(() => import("./Pages/SuccessStories/SuccessStories"));
+const Blog                   = lazy(() => import("./Pages/Blog/Blog_new"));
+const Policy                 = lazy(() => import("./Pages/Policy/Policy"));
+const Values                 = lazy(() => import("./Pages/Values/Values"));
+const MayNewsletter          = lazy(() => import("./Pages/Newsletters/MayNewsletter"));
+const June2025Newsletter     = lazy(() => import("./Pages/Newsletters/June2025"));
+const Aug2025Newsletter      = lazy(() => import("./Pages/Newsletters/Aug2025"));
+const October2025Newsletter  = lazy(() => import("./Pages/Newsletters/October2025"));
+const November2025Newsletter = lazy(() => import("./Pages/Newsletters/November2025"));
+const December2025Newsletter = lazy(() => import("./Pages/Newsletters/December2025"));
+const January2026Newsletter  = lazy(() => import("./Pages/Newsletters/January2026"));
+const February2026Newsletter = lazy(() => import("./Pages/Newsletters/February2026"));
 // ******************************************
 import { RouterProvider, createBrowserRouter } from "react-router-dom";
 import { useEffect } from "react";
-import Values from "./Pages/Values/Values";
 
 const router = createBrowserRouter([
   {

--- a/src/Components/PageLoader/PageLoader.jsx
+++ b/src/Components/PageLoader/PageLoader.jsx
@@ -1,0 +1,13 @@
+const PageLoader = () => {
+  return (
+    <div className="w-full min-h-screen bg-grey200 flex justify-center items-center pt-20">
+      <div
+        className="w-12 h-12 rounded-full border-4 border-grey400 border-t-primary500"
+        style={{ animation: "spin 0.8s linear infinite" }}
+      />
+      <style>{`@keyframes spin { to { transform: rotate(360deg); } }`}</style>
+    </div>
+  );
+};
+
+export default PageLoader;

--- a/src/Components/SiteLayout/SiteLayout.jsx
+++ b/src/Components/SiteLayout/SiteLayout.jsx
@@ -3,8 +3,9 @@ import Footer from "../Footer/Footer";
 
 import { Outlet, ScrollRestoration, useLocation } from "react-router-dom";
 import KeelBot from "../KeelBot/KeelBot";
-import { useEffect } from "react";
+import { useEffect, Suspense } from "react";
 import ReactGA from "react-ga4";
+import PageLoader from "../PageLoader/PageLoader";
 
 const SiteLayout = () => {
   const location = useLocation();
@@ -22,7 +23,9 @@ const SiteLayout = () => {
       <Navbar />
       {/* <KeelBot /> */}
       <ScrollRestoration />
-      <Outlet />
+      <Suspense fallback={<PageLoader />}>
+        <Outlet />
+      </Suspense>
       <Footer />
     </div>
   );


### PR DESCRIPTION
## Summary
- Converted 18 static page imports in `App.jsx` to `React.lazy()`
- Added `<Suspense>` boundary in `SiteLayout.jsx` wrapping `<Outlet />` — only the content area suspends, Navbar and Footer stay visible during navigation
- Added `src/Components/PageLoader/PageLoader.jsx` — branded spinner using existing Tailwind tokens (`bg-grey200`, `border-t-primary500`)

## What stays static
- `SiteLayout` — needed immediately on every page load
- `Error` — needed immediately as the router's `errorElement`

## Expected Impact
~15-20% reduction in initial JS bundle size. Newsletter pages (8 chunks) are especially impactful as they were previously bundled even for users who never visit them.

Closes #81