### PR TITLE
docs: Google Apps Scripts knowledge transfer

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,28 @@
+# KeelWorks Website Documentation
+
+This folder contains technical documentation for maintainers and future developers of the KeelWorks website.
+
+## Structure
+
+```
+docs/
+├── README.md                          ← You are here
+└── integrations/
+    └── google-apps-scripts/
+        ├── README.md                  ← Overview of all scripts + status
+        ├── newsletter-subscribe.md    ← Footer subscribe form
+        ├── job-listings.md            ← Careers page job listings
+        ├── job-application.md         ← Job application form
+        ├── volunteer-signup.md        ← Volunteer sign-up form
+        ├── contact-form.md            ← Contact us form
+        ├── blog-media.md              ← Blog page YouTube/media feed
+        └── how-to-recreate.md         ← Step-by-step guide if a script breaks
+```
+
+## Quick Reference
+
+The website uses **Google Apps Script** as a lightweight backend for all form submissions and data fetching. If any form stops working, start with [integrations/google-apps-scripts/README.md](integrations/google-apps-scripts/README.md).
+
+## History
+
+In early 2026, the Google account of a former team member (Thomas Garrod) was deleted. This broke several Google Apps Script deployments that were owned by that account. The newsletter subscribe, contact form, and blog media scripts had to be recreated. See [how-to-recreate.md](integrations/google-apps-scripts/how-to-recreate.md) to handle this situation in the future.

--- a/docs/integrations/google-apps-scripts/README.md
+++ b/docs/integrations/google-apps-scripts/README.md
@@ -1,0 +1,69 @@
+# Google Apps Scripts — Overview
+
+The KeelWorks website uses Google Apps Script as a lightweight backend. Scripts are deployed as web apps and called directly from the React frontend. All scripts are owned by `mihir-ravindra.adelkar@keelworks.org` (as of March 2026).
+
+> **Warning:** If the owning account is ever deleted, all scripts break. See [how-to-recreate.md](how-to-recreate.md).
+
+---
+
+## Script Inventory
+
+| Feature | Status | Script Name (apps script) | Source File |
+|---|---|---|---|
+| Newsletter Subscribe | ✅ Working | _(no named project — standalone deployment)_ | `src/Components/Footer/Footer.jsx` |
+| Job Listings (fetch) | ✅ Working | `Job Listings API` | `src/Pages/Careers/Careers.jsx` |
+| Job Application (submit) | ⚠️ Needs re-auth | `KeelWorks Job Application Handler` | `src/Pages/Careers/JobApplicationForm.jsx` |
+| Volunteer Sign-Up | ⚠️ Needs verification | `Volunteer App Drive API` | `src/Pages/GetInvolved/SignUp/SignUp.jsx` |
+| Contact Form | ❌ Broken | _(deleted with old account)_ | `src/Pages/ContactUs/ContactForm/ContactForm.jsx` |
+| Blog Media (YouTube) | ❌ Broken | _(deleted with old account)_ | `src/Pages/Blog/Blog_new.jsx` |
+
+---
+
+## Deployed URLs (as of March 2026)
+
+| Feature | URL |
+|---|---|
+| Newsletter Subscribe | `https://script.google.com/macros/s/AKfycbyOKVVVZPGJWOTntJ_uwlPJrdVNe6LET_VMSIJHZUtXki8qR6ZTiKso4UEZs8n0JCHp/exec` |
+| Job Listings | `https://script.google.com/macros/s/AKfycbzEmskmmWo59MhJzsTrJwNGWK9EottKP4CvDNb5F70ZLRJbdSs1Jd1VrjgLQ6r_Ik6CwA/exec` |
+| Job Application | `https://script.google.com/macros/s/AKfycbzyLaq4bWvqApKMgJxkoQNu1tZKWLJvVLfYyKqhUvGVBjoyt37zzC2dH7XO2hmG-2pfWA/exec` |
+| Volunteer Sign-Up | `https://script.google.com/macros/s/AKfycbyRoPGVv2_M5LQuwcLpzlQtUX1ciR0wScaDaBxczOqnB2qDrSD8y8Tt0FtMJTfiT9In1gA/exec` |
+| Contact Form | ❌ Needs recreation |
+| Blog Media | ❌ Needs recreation |
+
+---
+
+## How Scripts Are Called
+
+All scripts receive HTTP POST requests from the browser. There are two patterns used:
+
+### Pattern A — JSON body (newsletter subscribe)
+```js
+fetch(url, {
+  method: "POST",
+  body: JSON.stringify({ email }),
+  mode: "no-cors",
+});
+```
+Script reads: `JSON.parse(e.postData.contents)`
+
+### Pattern B — FormData (job application, volunteer sign-up, contact form)
+```js
+const data = new FormData();
+data.append("fieldName", value);
+fetch(url, { method: "POST", body: data });
+```
+Script reads: `e.parameter.fieldName`
+
+> `mode: "no-cors"` is required for scripts that only write data (subscribe, contact). Scripts that return data (job listings) do not use `no-cors` so the response can be read.
+
+---
+
+## Detailed Docs
+
+- [Newsletter Subscribe](newsletter-subscribe.md)
+- [Job Listings](job-listings.md)
+- [Job Application](job-application.md)
+- [Volunteer Sign-Up](volunteer-signup.md)
+- [Contact Form](contact-form.md)
+- [Blog Media](blog-media.md)
+- [How to Recreate a Broken Script](how-to-recreate.md)

--- a/docs/integrations/google-apps-scripts/blog-media.md
+++ b/docs/integrations/google-apps-scripts/blog-media.md
@@ -1,0 +1,47 @@
+# Blog Media (YouTube Feed)
+
+Fetches YouTube video rows for the Media tab on the Blog page.
+
+## Status
+❌ Broken — original script was deleted with former team member's account. Needs recreation.
+
+## How to Recreate
+1. Create a new Google Sheet with columns: `title`, `videoId` (YouTube video ID, not full URL)
+2. Create a new Apps Script project at [script.google.com](https://script.google.com)
+3. Use the script code below, replacing `YOUR_SHEET_ID`
+4. Deploy as a web app: Execute as **Me**, Who has access **Anyone**
+5. Copy the deployed URL and update `SHEET_URL` in `src/Pages/Blog/Blog_new.jsx` line 17
+
+## Frontend
+- **File:** `src/Pages/Blog/Blog_new.jsx`
+- **Constant:** `SHEET_URL` (line 17)
+- **Trigger:** Page load when Media tab is active
+- **Method:** GET
+- **Response:** JSON array of video objects
+
+## Script Code to Recreate
+```js
+function doGet() {
+  const ss = SpreadsheetApp.openById("YOUR_SHEET_ID");
+  const sheet = ss.getSheetByName("Sheet1");
+  const data = sheet.getDataRange().getValues();
+
+  const headers = data[0];
+  const rows = data.slice(1).map(row => {
+    const obj = {};
+    headers.forEach((h, i) => obj[h] = row[i]);
+    return obj;
+  });
+
+  return ContentService
+    .createTextOutput(JSON.stringify(rows))
+    .setMimeType(ContentService.MimeType.JSON);
+}
+```
+
+## Note on Blog Articles
+Blog articles (not videos) are fetched from a separate WordPress instance at `https://blog.keelworks.org/wp-json/wp/v2/posts?_embed`. This is independent of Google Apps Script and is working separately.
+
+## History
+- Original script owned by former team member — deleted in early 2026
+- Not yet recreated as of March 30, 2026

--- a/docs/integrations/google-apps-scripts/contact-form.md
+++ b/docs/integrations/google-apps-scripts/contact-form.md
@@ -1,0 +1,52 @@
+# Contact Form
+
+Handles messages submitted via the Contact Us page.
+
+## Status
+❌ Broken — original script was deleted with former team member's account. Needs recreation.
+
+## How to Recreate
+1. Create a new Google Sheet with columns: `First Name`, `Last Name`, `Email`, `Subject`, `Message`, `Timestamp`
+2. Create a new Apps Script project at [script.google.com](https://script.google.com)
+3. Use the script code below, replacing `YOUR_SHEET_ID`
+4. Deploy as a web app: Execute as **Me**, Who has access **Anyone**
+5. Copy the deployed URL and update `src/Pages/ContactUs/ContactForm/ContactForm.jsx` line 31
+
+## Frontend
+- **File:** `src/Pages/ContactUs/ContactForm/ContactForm.jsx`
+- **Method:** POST with `FormData`
+- **Note:** Currently uses `response.ok` check which will fail due to CORS — should be updated to use `mode: "no-cors"` + try/catch (same fix applied to newsletter subscribe)
+
+## Fields Sent
+| FormData Key | Description |
+|---|---|
+| `firstName` | First name |
+| `lastName` | Last name |
+| `email` | Email address |
+| `subject` | Message subject |
+| `message` | Message body |
+
+## Script Code to Recreate
+```js
+function doPost(e) {
+  const ss = SpreadsheetApp.openById("YOUR_SHEET_ID");
+  const sheet = ss.getSheetByName("Sheet1");
+
+  sheet.appendRow([
+    e.parameter.firstName,
+    e.parameter.lastName,
+    e.parameter.email,
+    e.parameter.subject,
+    e.parameter.message,
+    new Date()
+  ]);
+
+  return ContentService
+    .createTextOutput("OK")
+    .setMimeType(ContentService.MimeType.TEXT);
+}
+```
+
+## History
+- Original script owned by former team member — deleted in early 2026
+- Not yet recreated as of March 30, 2026

--- a/docs/integrations/google-apps-scripts/how-to-recreate.md
+++ b/docs/integrations/google-apps-scripts/how-to-recreate.md
@@ -1,0 +1,74 @@
+# How to Recreate a Broken Google Apps Script
+
+Use this guide whenever a script stops working — most commonly when the owning account is deleted or loses access.
+
+---
+
+## Step 1 — Identify which script is broken
+
+Check the browser console (F12 → Console) for network errors, or open the Apps Script dashboard at [script.google.com](https://script.google.com) and look at the **Executions** log for errors.
+
+Cross-reference with the [script inventory](README.md#script-inventory) to find the affected file.
+
+---
+
+## Step 2 — Check if the script still exists
+
+Go to [script.google.com](https://script.google.com) and search for the script by name. If it exists but is just unauthorized:
+
+1. Open the script
+2. Click **Run** on any function
+3. Authorize with your `@keelworks.org` account (click **Advanced** → **Go to [name] (unsafe)** if prompted)
+4. Go to **Deploy** → **Manage deployments** → confirm URL is correct and access is **Anyone**
+
+If the script is gone entirely, continue to Step 3.
+
+---
+
+## Step 3 — Recreate the script
+
+1. Go to [script.google.com](https://script.google.com) → **New project**
+2. Name it clearly (e.g. `KeelWorks Contact Form Handler`)
+3. Paste the script code from the relevant doc:
+   - [Newsletter Subscribe](newsletter-subscribe.md)
+   - [Contact Form](contact-form.md)
+   - [Blog Media](blog-media.md)
+4. Replace `YOUR_SHEET_ID` with the ID from the corresponding Google Sheet
+   - Sheet ID is in the URL: `docs.google.com/spreadsheets/d/`**`SHEET_ID`**`/edit`
+
+---
+
+## Step 4 — Deploy as a web app
+
+1. Click **Deploy** → **New deployment**
+2. Click the gear icon → select **Web app**
+3. Set:
+   - **Description:** anything descriptive
+   - **Execute as:** Me
+   - **Who has access:** Anyone
+4. Click **Deploy**
+5. Copy the web app URL
+
+---
+
+## Step 5 — Update the frontend
+
+Find the hardcoded URL in the source file (see [README.md](README.md#script-inventory) for file locations) and replace it with the new URL.
+
+---
+
+## Step 6 — Test
+
+- Open the website locally (`npm run dev`)
+- Submit the form
+- Check the Google Sheet for a new row
+- Check Apps Script **Executions** log for any errors
+
+---
+
+## Important Notes
+
+- **Always use a shared org account** (e.g. `mihir-ravindra.adelkar@keelworks.org`) to own scripts — never a personal account. This prevents scripts from breaking when someone leaves.
+- **`mode: "no-cors"`** must be used on any fetch that only writes data (subscribe, contact, sign-up). You cannot read the response in this mode — use try/catch and assume success.
+- **Scripts that return data** (job listings, blog media) must NOT use `mode: "no-cors"` — the response needs to be readable.
+- **`muteHttpExceptions: true`** is a Google Apps Script server-side option. It has no effect when passed as a browser `fetch` option — do not use it in React code.

--- a/docs/integrations/google-apps-scripts/job-application.md
+++ b/docs/integrations/google-apps-scripts/job-application.md
@@ -1,0 +1,42 @@
+# Job Application Handler
+
+Receives job applications (including resume file upload) submitted via the Careers page.
+
+## Status
+⚠️ Needs re-authorization (script exists but lost auth when original owner's account was deleted)
+
+## To Fix
+1. Open `KeelWorks Job Application Handler` in [script.google.com](https://script.google.com)
+2. Click **Run** on any function to trigger the authorization prompt
+3. Authorize with your `@keelworks.org` account
+4. Go to **Deploy** → **Manage deployments** → verify the URL matches the one below
+5. Ensure **Who has access** is set to **Anyone**
+
+## Frontend
+- **File:** `src/Pages/Careers/JobApplicationForm.jsx`
+- **Trigger:** User submits the job application form
+- **Method:** POST with `FormData`
+- **Special:** Resume file is converted to base64 before sending
+
+## Fields Sent
+| FormData Key | Description |
+|---|---|
+| `firstName`, `middleName`, `lastName` | Applicant name |
+| `fullName` | Combined full name |
+| `birthDate` | Date of birth |
+| `address1`, `address2`, `city`, `state`, `zip` | Address |
+| `email` | Email address |
+| `phone` | Phone number |
+| `linkedin` | LinkedIn profile URL |
+| `position` | Job title (from URL slug) |
+| `source` | How they heard about the role |
+| `startDate` | Available start date |
+| `fileContent` | Base64-encoded resume file |
+| `mimeType` | Resume file MIME type |
+| `fileName` | Resume file name |
+| `coverLetter` | Cover letter text |
+
+## Script
+- **Owner:** `mihir-ravindra.adelkar@keelworks.org` (needs re-auth)
+- **Project Name:** `KeelWorks Job Application Handler`
+- **URL:** `https://script.google.com/macros/s/AKfycbzyLaq4bWvqApKMgJxkoQNu1tZKWLJvVLfYyKqhUvGVBjoyt37zzC2dH7XO2hmG-2pfWA/exec`

--- a/docs/integrations/google-apps-scripts/job-listings.md
+++ b/docs/integrations/google-apps-scripts/job-listings.md
@@ -1,0 +1,70 @@
+# Job Listings
+
+Fetches open job/volunteer opportunities and displays them on the Careers page.
+
+## Status
+✅ Working
+
+## Frontend
+- **File:** `src/Pages/Careers/Careers.jsx`
+- **Trigger:** Page load (useEffect)
+- **Method:** GET
+- **Response:** JSON array of job objects
+
+## Script
+- **Owner:** `mihir-ravindra.adelkar@keelworks.org`
+- **Project Name:** `Job Listings API` (in Google Apps Script)
+- **URL:** `https://script.google.com/macros/s/AKfycbzEmskmmWo59MhJzsTrJwNGWK9EottKP4CvDNb5F70ZLRJbdSs1Jd1VrjgLQ6r_Ik6CwA/exec`
+- **Google Sheet ID:** `1lEuDkfigGllE9ZOvocHix4r2ZcYXwNVzhQ1DQHZy68U`
+- **Tab:** `Sheet1`
+
+## Sheet Column Structure
+The script uses the first row as headers and returns all rows as JSON objects. The frontend (`Careers.jsx`) is flexible about column names but expects these fields:
+
+| Column Header | Purpose | Fallback |
+|---|---|---|
+| `Title` / `Job Title` / `Role` | Job title | `"Role (title pending)"` |
+| `Location` / `City` | Location | `"Remote"` |
+| `Type` / `Role Type` | Role type | `"Volunteer"` |
+| `Description` / `Job Description` | Full description | `""` |
+| `Status` / `State` | **Must be `open`** to display | hidden |
+| `FormURL` / `Form URL` / `Apply Link` | Link for Apply Now button | alert shown |
+
+> Only rows where `Status` = `open` (case-insensitive) are shown on the page.
+
+## Script Code
+```js
+function doGet(e) {
+  const SHEET_ID = '1lEuDkfigGllE9ZOvocHix4r2ZcYXwNVzhQ1DQHZy68U';
+  const spreadsheet = SpreadsheetApp.openById(SHEET_ID);
+  const sheet = spreadsheet.getSheetByName('Sheet1');
+  const data = sheet.getDataRange().getValues();
+
+  if (data.length === 0) {
+    return ContentService
+      .createTextOutput(JSON.stringify([]))
+      .setMimeType(ContentService.MimeType.JSON);
+  }
+
+  const headers = data[0];
+  const jsonData = [];
+
+  for (let i = 1; i < data.length; i++) {
+    let row = {};
+    for (let j = 0; j < headers.length; j++) {
+      let value = data[i][j];
+      if (value instanceof Date) value = value.toISOString();
+      row[headers[j]] = value || '';
+    }
+    jsonData.push(row);
+  }
+
+  return ContentService
+    .createTextOutput(JSON.stringify(jsonData))
+    .setMimeType(ContentService.MimeType.JSON);
+}
+
+function doPost(e) {
+  return doGet(e);
+}
+```

--- a/docs/integrations/google-apps-scripts/newsletter-subscribe.md
+++ b/docs/integrations/google-apps-scripts/newsletter-subscribe.md
@@ -1,0 +1,41 @@
+# Newsletter Subscribe
+
+Allows visitors to subscribe via the footer form on every page.
+
+## Status
+✅ Working (recreated March 2026)
+
+## Frontend
+- **File:** `src/Components/Footer/Footer.jsx`
+- **Trigger:** User submits email in the "Let's Connect!" footer form
+- **Method:** POST with JSON body `{ email: "..." }`
+- **Mode:** `no-cors` (write-only, response not read)
+
+## Script
+- **Owner:** `mihir-ravindra.adelkar@keelworks.org`
+- **URL:** `https://script.google.com/macros/s/AKfycbyOKVVVZPGJWOTntJ_uwlPJrdVNe6LET_VMSIJHZUtXki8qR6ZTiKso4UEZs8n0JCHp/exec`
+- **Google Sheet:** `Newsletter subscribe KeelWorks Main Site`
+  - Sheet ID: `1Wrs2c3voInmDLwPEVCypfLPMon7jPhff2juB8oahBvA`
+  - Tab: `Sheet1`
+  - Columns: `email`, `timestamp`
+
+## Script Code
+```js
+function doPost(e) {
+  const { email } = JSON.parse(e.postData.contents);
+
+  const ss = SpreadsheetApp.openById("1Wrs2c3voInmDLwPEVCypfLPMon7jPhff2juB8oahBvA");
+  const sheet = ss.getSheetByName("Sheet1");
+
+  sheet.appendRow([email, new Date()]);
+
+  return ContentService
+    .createTextOutput("OK")
+    .setMimeType(ContentService.MimeType.TEXT);
+}
+```
+
+## History
+- Original script was owned by a former team member whose account was deleted in early 2026
+- Recreated March 30, 2026 by Mihir Adelkar
+- Frontend was also fixed at the same time: switched from `FormData` to `JSON.stringify`, added `mode: "no-cors"`, and wrapped in try/catch

--- a/docs/integrations/google-apps-scripts/volunteer-signup.md
+++ b/docs/integrations/google-apps-scripts/volunteer-signup.md
@@ -1,0 +1,23 @@
+# Volunteer Sign-Up
+
+Handles volunteer applications submitted via the Get Involved page.
+
+## Status
+⚠️ Needs verification (script exists — `Volunteer App Drive API` — but URL and auth need to be confirmed)
+
+## To Verify
+1. Open `Volunteer App Drive API` in [script.google.com](https://script.google.com)
+2. Go to **Deploy** → **Manage deployments**
+3. Check the URL matches: `https://script.google.com/macros/s/AKfycbyRoPGVv2_M5LQuwcLpzlQtUX1ciR0wScaDaBxczOqnB2qDrSD8y8Tt0FtMJTfiT9In1gA/exec`
+4. If URL changed, update `SIGNUP_SHEET_MASTER_URL` in `src/Pages/GetInvolved/SignUp/SignUp.jsx` line 351
+5. Re-authorize if needed (same steps as job application)
+
+## Frontend
+- **File:** `src/Pages/GetInvolved/SignUp/SignUp.jsx`
+- **Trigger:** User submits volunteer application
+- **Method:** POST with `FormData`
+- **Note:** There is also a `TESTING_URL` (line 347) that is unused — can be removed
+
+## Script
+- **Project Name:** `Volunteer App Drive API`
+- **URL:** `https://script.google.com/macros/s/AKfycbyRoPGVv2_M5LQuwcLpzlQtUX1ciR0wScaDaBxczOqnB2qDrSD8y8Tt0FtMJTfiT9In1gA/exec`


### PR DESCRIPTION
## Summary
- Adds `/docs` folder with full knowledge transfer documentation for all Google Apps Script integrations
- Documents current status of each script (working, needs re-auth, broken)
- Includes deployed URLs, sheet IDs, script code, and field references for each integration
- Adds step-by-step recreation guide for when scripts break in the future

## Context
A former team member's Google account was deleted, breaking several script deployments. This doc ensures the next person knows exactly what to do if this happens again.

## Scripts Documented
| Feature | Status |
|---|---|
| Newsletter Subscribe | ✅ Fixed today |
| Job Listings | ✅ Working |
| Job Application Handler | ⚠️ Needs re-auth |
| Volunteer Sign-Up | ⚠️ Needs verification |
| Contact Form | ❌ Needs recreation |
| Blog Media (YouTube) | ❌ Needs recreation |

## Test plan
- [ ] Review docs for accuracy
- [ ] Confirm links between docs are correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)