### PR TITLE
feat: add Mar/Apr/May 2026 newsletters and fix contact form

### DIFF
--- a/docs/integrations/google-apps-scripts/README.md
+++ b/docs/integrations/google-apps-scripts/README.md
@@ -14,7 +14,7 @@ The KeelWorks website uses Google Apps Script as a lightweight backend. Scripts 
 | Job Listings (fetch) | ✅ Working | `Job Listings API` | `src/Pages/Careers/Careers.jsx` |
 | Job Application (submit) | ⚠️ Needs re-auth | `KeelWorks Job Application Handler` | `src/Pages/Careers/JobApplicationForm.jsx` |
 | Volunteer Sign-Up | ⚠️ Needs verification | `Volunteer App Drive API` | `src/Pages/GetInvolved/SignUp/SignUp.jsx` |
-| Contact Form | ❌ Broken | _(deleted with old account)_ | `src/Pages/ContactUs/ContactForm/ContactForm.jsx` |
+| Contact Form | ✅ Working | `Contact Form Handler` | `src/Pages/ContactUs/ContactForm/ContactForm.jsx` |
 | Blog Media (YouTube) | ❌ Broken | _(deleted with old account)_ | `src/Pages/Blog/Blog_new.jsx` |
 
 ---
@@ -27,7 +27,7 @@ The KeelWorks website uses Google Apps Script as a lightweight backend. Scripts 
 | Job Listings | `https://script.google.com/macros/s/AKfycbzEmskmmWo59MhJzsTrJwNGWK9EottKP4CvDNb5F70ZLRJbdSs1Jd1VrjgLQ6r_Ik6CwA/exec` |
 | Job Application | `https://script.google.com/macros/s/AKfycbzyLaq4bWvqApKMgJxkoQNu1tZKWLJvVLfYyKqhUvGVBjoyt37zzC2dH7XO2hmG-2pfWA/exec` |
 | Volunteer Sign-Up | `https://script.google.com/macros/s/AKfycbyRoPGVv2_M5LQuwcLpzlQtUX1ciR0wScaDaBxczOqnB2qDrSD8y8Tt0FtMJTfiT9In1gA/exec` |
-| Contact Form | ❌ Needs recreation |
+| Contact Form | `https://script.google.com/a/macros/keelworks.org/s/AKfycbwzCrtLdH3DM4wdFf5u3wSBtdbeSLGQQPOKmPcKnddDiCq1lcYjRgsFSVK0PIE_opsK/exec` |
 | Blog Media | ❌ Needs recreation |
 
 ---

--- a/docs/integrations/google-apps-scripts/contact-form.md
+++ b/docs/integrations/google-apps-scripts/contact-form.md
@@ -3,7 +3,7 @@
 Handles messages submitted via the Contact Us page.
 
 ## Status
-❌ Broken — original script was deleted with former team member's account. Needs recreation.
+✅ Working (recreated May 2026)
 
 ## How to Recreate
 1. Create a new Google Sheet with columns: `First Name`, `Last Name`, `Email`, `Subject`, `Message`, `Timestamp`
@@ -14,11 +14,11 @@ Handles messages submitted via the Contact Us page.
 
 ## Frontend
 - **File:** `src/Pages/ContactUs/ContactForm/ContactForm.jsx`
-- **Method:** POST with `FormData`
-- **Note:** Currently uses `response.ok` check which will fail due to CORS — should be updated to use `mode: "no-cors"` + try/catch (same fix applied to newsletter subscribe)
+- **Method:** POST with JSON body (`JSON.stringify`)
+- **Mode:** `no-cors` (write-only, response not read)
 
-## Fields Sent
-| FormData Key | Description |
+## Fields Sent (JSON body)
+| Key | Description |
 |---|---|
 | `firstName` | First name |
 | `lastName` | Last name |
@@ -29,17 +29,19 @@ Handles messages submitted via the Contact Us page.
 ## Script Code to Recreate
 ```js
 function doPost(e) {
+  const { firstName, lastName, email, subject, message } = JSON.parse(e.postData.contents);
+
   const ss = SpreadsheetApp.openById("YOUR_SHEET_ID");
   const sheet = ss.getSheetByName("Sheet1");
 
-  sheet.appendRow([
-    e.parameter.firstName,
-    e.parameter.lastName,
-    e.parameter.email,
-    e.parameter.subject,
-    e.parameter.message,
-    new Date()
-  ]);
+  sheet.appendRow([firstName, lastName, email, subject, message, new Date()]);
+
+  const recipient = "YOUR_NOTIFICATION_EMAIL@keelworks.org";
+  MailApp.sendEmail(
+    recipient,
+    "New Contact Form Submission: " + (subject || "(no subject)"),
+    `From: ${firstName} ${lastName}\nEmail: ${email}\nSubject: ${subject}\n\nMessage:\n${message}`
+  );
 
   return ContentService
     .createTextOutput("OK")
@@ -49,4 +51,5 @@ function doPost(e) {
 
 ## History
 - Original script owned by former team member — deleted in early 2026
-- Not yet recreated as of March 30, 2026
+- Recreated May 2026 by Mihir Adelkar
+- Frontend fixed at the same time: switched from FormData to JSON.stringify, added mode: "no-cors", wrapped in try/catch

--- a/src/Pages/ContactUs/ContactForm/ContactForm.jsx
+++ b/src/Pages/ContactUs/ContactForm/ContactForm.jsx
@@ -10,39 +10,23 @@ const ContactForm = () => {
 
   const handleSubmit = async (e) => {
     e.preventDefault();
-    const userInput = {
-      firstName,
-      lastName,
-      email,
-      subject,
-      message,
-    };
 
-    console.log(userInput);
-
-    const data = new FormData();
-    data.append("firstName", userInput.firstName);
-    data.append("lastName", userInput.lastName);
-    data.append("email", userInput.email);
-    data.append("subject", userInput.subject);
-    data.append("message", userInput.message);
-
-    const response = await fetch(
-      "https://script.google.com/macros/s/AKfycbxKcRVIgBWaNgw09-9desJnhKJYrNzK2kxY4rgBh5Kne-3DALwJVz4XAnyud4VnKe7S/exec",
-      {
-        method: "POST",
-        body: data,
-        muteHttpExceptions: true,
-      },
-    );
-
-    if (response.ok) {
+    try {
+      await fetch(
+        "https://script.google.com/a/macros/keelworks.org/s/AKfycbwzCrtLdH3DM4wdFf5u3wSBtdbeSLGQQPOKmPcKnddDiCq1lcYjRgsFSVK0PIE_opsK/exec",
+        {
+          method: "POST",
+          body: JSON.stringify({ firstName, lastName, email, subject, message }),
+          mode: "no-cors",
+        },
+      );
       setFirstName("");
       setLastName("");
       setEmail("");
       setSubject("");
       setMessage("");
-    } else {
+      alert("Your message was sent successfully! Thank you.");
+    } catch {
       alert("There was an error sending your message.");
     }
   };


### PR DESCRIPTION
## Summary
- Adds March, April, and May 2026 newsletter entries to the blog
- Fixes contact form not including sender name, email, subject, or message in notification emails

## Contact Form Fix
The root cause was the same CORS redirect issue previously fixed for newsletter subscribe: without `mode: "no-cors"`, Google Apps Script's redirect drops the POST body, so the script receives an empty request and sends a blank notification email.

Changes:
- Switched `ContactForm.jsx` from `FormData` to `JSON.stringify` + `mode: "no-cors"` + try/catch
- Recreated the Google Apps Script (old one was deleted with a former team member's account) with JSON parsing and a `MailApp` notification that includes sender name, email, subject, and message
- Updated `docs/integrations/google-apps-scripts/` to reflect working status and new script code

## Test plan
- [x] Submitted contact form locally — success alert shown, form cleared
- [x] Verified POST body contains all fields (firstName, lastName, email, subject, message)
- [x] Confirmed new row appears in Google Sheet
- [x] Confirmed notification email received with full sender details

🤖 Generated with [Claude Code](https://claude.com/claude-code)